### PR TITLE
Add SSL configuration for placement API overlay

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -506,6 +506,10 @@ do
             MOD_OVERLAYS+=( "openstack-dashboard-ha.yaml" )
             set -- $@ --openstack-dashboard && cache $@
             ;;
+        --placement-ha*)
+            get_units $1 __NUM_NOVA_PLACEMENT_UNITS__ 3
+            MOD_OVERLAYS+=( "placement-ha.yaml" )
+            ;;
         --swift)
             conflicts_with $1 --ceph-rgw
             MOD_OVERLAYS+=( "swift.yaml" )
@@ -596,7 +600,7 @@ do
                 set -- $@ $svc_ha:$units && cache $@
             done
             # now check optional overlays
-            for svc in openstack-dashboard swift ceph-rgw; do
+            for svc in openstack-dashboard swift ceph-rgw placement; do
                 svc_ha=--${svc}-ha
                 # don't override ones that have been explicity provided as HA and
                 # ignore ones that are not even requested.

--- a/overlays/placement-ha.yaml
+++ b/overlays/placement-ha.yaml
@@ -1,0 +1,10 @@
+applications:
+  placement:
+    options:
+      vip: __VIP__
+  placement-hacluster:
+    charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
+    options:
+        cluster_count: __NUM_NOVA_PLACEMENT_UNITS__
+relations:
+  - [ placement, placement-hacluster ]

--- a/overlays/placement.yaml
+++ b/overlays/placement.yaml
@@ -2,6 +2,10 @@
 debug:                      &debug                     True
 openstack_origin:           &openstack_origin          __OS_ORIGIN__
 
+ssl_ca:                     &ssl_ca                    __SSL_CA__
+ssl_cert:                   &ssl_cert                  __SSL_CERT__
+ssl_key:                    &ssl_key                   __SSL_KEY__
+
 applications:
   placement:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__placement
@@ -10,6 +14,10 @@ applications:
     options:
       debug: *debug
       openstack-origin: *openstack_origin
+      ssl_ca: *ssl_ca
+      ssl_cert: *ssl_cert
+      ssl_key: *ssl_key
+
 relations:
   - [ placement:shared-db, __MYSQL_INTERFACE__ ]
   - [ placement, keystone ]


### PR DESCRIPTION
This patch aims to add the option to configure SSL on the placement API unit.

Since there isa no HA option for placement API, and since the other units
are using their HA overlay with 1 unit, I have added that as well for the
placement API.

I have taken they keystone-ha and SSL configuration as reference.

Signed-off-by: David Negreira <david.negreira@canonical.com>