### PR TITLE
Octavia OVN provider only works after Ussuri

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -386,6 +386,7 @@ do
             ;;
         --octavia-ovn-provider)
             MOD_OVERLAYS+=( "octavia-ovn-provider.yaml" )
+            assert_min_release victoria octavia-ovn-provider
             # ensure octavia and ovn
             set -- $@ --octavia && cache $@
             set -- $@ --ovn && cache $@


### PR DESCRIPTION
Adding this switch since this configuration is
not supported for versions prior to Victoria.

Closes #22