### PR TITLE
Skip prefix for non-osm grafana

### DIFF
--- a/common/generate-bundle.sh
+++ b/common/generate-bundle.sh
@@ -6,6 +6,6 @@ MOD_DIR=`dirname $0`
 . $MOD_DIR/pipeline/02configure
 . $MOD_DIR/pipeline/03build
 # Ensure no unrendered variables
-out="`grep -r __ $MOD_DIR/b/${MASTER_OPTS[BUNDLE_NAME]} --exclude=config --exclude-dir=p`" || exit 0
+out="`grep -r __ $MOD_DIR/b/${MASTER_OPTS[BUNDLE_NAME]} --exclude=config --exclude-dir=p| egrep -v '^.*#'`" || exit 0
 echo -e "ERROR: there are unrendered variables in your bundle:\n$out"
 exit 1

--- a/common/render.d/all
+++ b/common/render.d/all
@@ -16,7 +16,7 @@ render_mod_params ()
 
     local charms
     # get list of charms in this template
-    readarray -t charms<<<`sed -rn 's,.+ charm:\s+.+__CHARM_CH_PREFIX__(.+)\s*$,\1,p' $1`
+    readarray -t charms<<<`sed -rn 's,.+ charm:\s+.+__CHARM_CH_PREFIX__(__SKIP_PREFIX__)?(.+)\s*$,\2,p' $template`
 
     config_renderer=`mktemp`
     export INTERNAL_BUNDLE_CONFIG=`mktemp`
@@ -28,8 +28,12 @@ render_mod_params ()
             channel=${CHARM_CHANNEL[$c]:-$service_default_channel}
             echo "-e '/__CHARM_CS_NS____CHARM_CH_PREFIX__${c}\s*$/a\ \ \ \ channel: $channel'" >> $config_renderer
 
-            prefix=${CH_PREFIXED_CHARMS[$c]:-""}
-            echo "-e 's,__CHARM_CS_NS____CHARM_CH_PREFIX__${c}\s*$,$prefix${c},'" >> $config_renderer
+            if `grep -q "__SKIP_PREFIX__$c" $template`; then
+                echo "-e 's,__CHARM_CS_NS____CHARM_CH_PREFIX____SKIP_PREFIX__${c}\s*$,${c},'" >> $config_renderer
+            else
+                prefix=${CH_PREFIXED_CHARMS[$c]:-""}
+                echo "-e 's,__CHARM_CS_NS____CHARM_CH_PREFIX__${c}\s*$,$prefix${c},'" >> $config_renderer
+            fi
         else
             # apply ns, if required, for each charm
             ns=${CS_NS_CHARMS[$c]:-""}

--- a/overlays/grafana.yaml
+++ b/overlays/grafana.yaml
@@ -1,6 +1,7 @@
 applications:
   grafana:
-    charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__grafana
+    # NOTE: using __SKIP_PREFIX__ to avoid getting clobbered by the osm version
+    charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX____SKIP_PREFIX__grafana
     num_units: 1
     constraints: mem=1G
     options:


### PR DESCRIPTION
The osm and lma charms each have their own version of
the grafana charm where the lma one has no prefix in
the charmhub.

Resolves: #30