### PR TITLE
Also lint `novarc`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Lint bash scripts
         run: |
-          bashate --ignore E006 --verbose tools/*.sh
+          bashate --ignore E006 --verbose tools/*.sh openstack/novarc

--- a/openstack/novarc
+++ b/openstack/novarc
@@ -61,7 +61,7 @@ else
     if [ "${_CONFIG_PASSWD}" == "none" ] || [ "${_CONFIG_PASSWD}" == "" ]; then
         export OS_PASSWORD=$(juju run -u keystone/leader leader-get admin_passwd)
     else
-	export OS_PASSWORD="$(juju config keystone admin-password)"
+    export OS_PASSWORD="$(juju config keystone admin-password)"
     fi
 fi
 export OS_REGION_NAME=RegionOne


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>