### PR TITLE
Explcitily specify source=distro instead of blank

### DIFF
--- a/common/helpers
+++ b/common/helpers
@@ -761,7 +761,7 @@ if [ -n "$ppa" ]; then
 elif ! ltsmatch "$series" "$release" && ! nonltsmatch "$series" "$release" ; then
     source="cloud:${series}-${release}"
 else
-    source=""
+    source="distro"
 fi
 if [ -n "$pocket" ]; then
     if [ -n "$source" ]; then


### PR DESCRIPTION
Charmhub charms (including git master) now set the charm default
openstack-origin/source option to the matching openstack release name
(e.g. 'wallaby') instead of the previous default of 'distro'.

As a result, if you try to test a git master charm against an older
OpenStack release that uses distro (e.g. ussuri) you will accidentally
upgrade that charm from the current release (e.g. focal-ussuri) to the
latest release in git master (e.g. focal-wallaby).

While this is not technically supported and some charms are now removing
support for older releases from git master, it's still OK to test some
charms like this and even if not supported it usually incorrectly
upgrades that application which breaks the environment and is difficult
to rollback leaving you having to spend another 30-60+ minutes
re-deploying your test environment.

To prevent that happening by default, explicitly specify 'distro'
instead of leaving source blank.
