### PR TITLE
mysql: Set tuning-level=fast

### DIFF
--- a/overlays/mysql-innodb-cluster.yaml
+++ b/overlays/mysql-innodb-cluster.yaml
@@ -10,4 +10,4 @@ applications:
       source: *source
       innodb-buffer-pool-size: 50%
       max-connections: 20000
-
+      tuning-level: fast

--- a/overlays/mysql.yaml
+++ b/overlays/mysql.yaml
@@ -13,3 +13,4 @@ applications:
       root-password: ChangeMe123
       sst-password: ChangeMe123
       min-cluster-size: __NUM_MYSQL_UNITS__
+      tuning-level: fast


### PR DESCRIPTION
Tell MySQL not to call sync for each individual database write, it will
still do so about once per second.

This adds a high load to the underlying storage which is slow in
stsstack, and, is only required to ensure we don't lose data in a crash.
This helps speed up all of the initial database migrations quite a bit
and will also lower the disk load on stsstack as a whole.

Since these are testing environments, it doesn't really matter, also
with openstack the one second or so of writes in the event of a
crash/poweroff are typically important - just status updates, etc.

Additionally in multi-node setups (e.g. mysql-ha or always in the case
of mysql-innodb-cluster) the write is done to all 3 nodes anyway and is
still kept if one node crashes or is powered off before the others.

I have used this for a year+ with no ill effect. We also sometimes run
this in production. The only time you would see an ill effect is if all
3 nodes crashed within less than a second, during the time a critical
write to an instance was made (e.g. it was live migrated) and that data
is something that OpenStack doesn't re-sync from another source. In
practice for a testing environment, this is very rare and not likely to
matter even if it does happen.
