### PR TITLE
Fix error counting length of the commit subject

### DIFF
--- a/tools/lint-git-messages.sh
+++ b/tools/lint-git-messages.sh
@@ -40,7 +40,7 @@ for sha in $(git rev-list --no-merges ${base_commit}..${head_commit}); do
 
     # Check subject
     echo "[INFO] ${sha} Checking subject: ${message[0]}"
-    if (( $(wc --chars <<<${message[0]}) > 50 )); then
+    if (( $(wc --chars <<<${message[0]}) > 51 )); then
         echo "[ERROR] Subject line is > 50 characters"
         exit 1
     fi

--- a/tools/lint-git-messages.sh
+++ b/tools/lint-git-messages.sh
@@ -56,7 +56,7 @@ for sha in $(git rev-list --no-merges ${base_commit}..${head_commit}); do
             exit 1
         fi
         for i in $(seq 2 $(( ${#message[@]} - 1 ))); do
-            if (( $(wc --chars <<<${message[${i}]}) > 72 )); then
+            if (( $(wc --chars <<<${message[${i}]}) > 73 )); then
                 echo "[ERROR] Body line is > 72 characters"
                 echo "  ${message[${i}]}"
                 exit 1


### PR DESCRIPTION
The command wc --chars <<<${subject} does not work right as it always counts one extra char. For example:

$ wc --chars <<<""
1

$ wc --chars <<<"12345678901234567890123456789012345678901234567890" 
51