### PR TITLE
Ensure default binding provided with maas

### DIFF
--- a/common/generate_bundle_base
+++ b/common/generate_bundle_base
@@ -81,6 +81,10 @@ mkdir -p $RENDER_PARTS_DIR
 . $MOD_DIR/common/render.d/all
 . $MOD_DIR/common/render.d/resources
 if ${MASTER_OPTS[HYPERCONVERGED_DEPLOYMENT]}; then
+    if [[ -z ${MASTER_OPTS[DEFAULT_BINDING]:-""} ]]; then
+        echo "ERROR: no default binding provided. Use --default-binding"
+        exit 1
+    fi
     PLACEMENT_OVERLAYS_DIR=$bundles_dir/p
     mkdir -p $PLACEMENT_OVERLAYS_DIR
     . $MOD_DIR/common/render.d/unit_placement

--- a/common/helpers
+++ b/common/helpers
@@ -1,7 +1,7 @@
 #!/bin/bash
 declare -a CACHED_STDIN=( $@ )
 declare -A MASTER_OPTS=(
-    [DEFAULT_BINDING]=alpha
+    [DEFAULT_BINDING]=
     [HYPERCONVERGED_DEPLOYMENT]=false
     [MODEL_CONFIG]=''
     [BUNDLE_NAME]=''


### PR DESCRIPTION
When using maas it is mandatory to set a default
binding that exists (see LP #1994124).