### PR TITLE
adding cinder:identity-service

### DIFF
--- a/openstack/openstack.yaml.template
+++ b/openstack/openstack.yaml.template
@@ -95,7 +95,7 @@ relations:
   - [ cinder:shared-db, __MYSQL_INTERFACE__ ]
   - [ cinder, rabbitmq-server ]
   - [ cinder, nova-cloud-controller ]
-  - [ cinder, keystone ]
+  - [ cinder:identity-service, keystone:identity-service ]
   - [ neutron-api:shared-db, __MYSQL_INTERFACE__ ]
   - [ neutron-api, rabbitmq-server ]
   - [ neutron-api, nova-cloud-controller ]


### PR DESCRIPTION
ERROR cannot deploy bundle: cannot add relation between "cinder" and "keystone": ambiguous relation: "cinder keystone" could refer to "cinder:identity-credentials keystone:identity-credentials"; "cinder:identity-service keystone:identity-service"

Closes #90 
