### PR TITLE
Cinder Improvements

### DIFF
--- a/openstack/openstack.yaml.template
+++ b/openstack/openstack.yaml.template
@@ -74,9 +74,7 @@ applications:
     options:
       debug: *debug
       verbose: *verbose
-      block-device: /var/disk.img
-      ephemeral-unmount: "/mnt"
-      overwrite: "true"
+      block-device: None
       glance-api-version: 2
       openstack-origin: *openstack_origin
       ssl_ca: *ssl_ca

--- a/overlays/cinder-lvm.yaml
+++ b/overlays/cinder-lvm.yaml
@@ -2,8 +2,12 @@ applications:
   cinder-lvm:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__cinder-lvm
     options:
-      alias: stsstack
-      allocation-type: thin
-      block-device: /var/lib/lvm_pool0.img|8G
+      allocation-type: auto
+      block-device: /dev/vdb
+      # https://bugs.launchpad.net/charm-cinder-lvm/+bug/1949074
+      config-flags: target_helper=lioadm
+  __CINDER_VOLUME_INTERFACE__:
+    storage:
+      block-devices: 'cinder,40G,1'
 relations:
   - [ __CINDER_VOLUME_INTERFACE__, cinder-lvm ]

--- a/overlays/cinder-purestorage.yaml
+++ b/overlays/cinder-purestorage.yaml
@@ -1,8 +1,4 @@
 applications:
-  cinder:
-    options:
-      block-device:  ''
-      ephemeral-unmount: ''
   cinder-purestorage:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__cinder-purestorage
     options:

--- a/overlays/cinder-volume.yaml
+++ b/overlays/cinder-volume.yaml
@@ -20,7 +20,7 @@ applications:
       debug: *debug
       verbose: *verbose
       enabled-services: volume
-      block-device:
+      block-device: None
       glance-api-version: 2
       openstack-origin: *openstack_origin
       ssl_ca: *ssl_ca
@@ -29,5 +29,4 @@ applications:
 relations:
   - [ cinder-volume:shared-db, __MYSQL_INTERFACE__ ]
   - [ cinder-volume, rabbitmq-server ]
-# Add when https://review.opendev.org/c/openstack/charm-cinder/+/845558 is merged
-#  - [ "cinder-volume:identity-credentials", keystone ]
+  - [ "cinder-volume:identity-credentials", keystone ]


### PR DESCRIPTION
Move LVM configuration from cinder to cinder-lvm charm
Use storage spaces to allocate storage for cinder-lvm
Use lioadm for cinder-lvm (bug workaround)
Use cinder-volume:identity-credentials by default
