### PR TITLE
Add jammy-zed support (OVN 22.09)

### DIFF
--- a/common/ch_channel_map/jammy-zed
+++ b/common/ch_channel_map/jammy-zed
@@ -1,0 +1,8 @@
+# These are charmhub mappings for charms that are outside of the main large
+# groupings like openstack and ceph etc.
+
+# Versions are based on https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html
+
+CHARM_CHANNEL[ovn-central]=22.09/edge
+CHARM_CHANNEL[ovn-chassis]=22.09/edge
+CHARM_CHANNEL[ovn-dedicated-chassis]=22.09/edge

--- a/openstack/openstack.yaml.template
+++ b/openstack/openstack.yaml.template
@@ -22,7 +22,6 @@ applications:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__rabbitmq-server
     constraints: mem=1G
     options:
-      source: *source
       min-cluster-size: __NUM_RABBIT_UNITS__
   nova-compute:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__nova-compute

--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -53,6 +53,11 @@ if has_min_release train; then
     set -- $@ --placement && cache $@
 fi
 
+# rabbitmq-server: Rely on charmhub channels for the source from jammy
+if ! has_min_series jammy; then
+    MOD_OVERLAYS+=( "rabbitmq-source.yaml" )
+fi
+
 get_amphora_ssh_pub_key ()
 {
     if ! [ -e $HOME/.ssh/id_amphora ]; then

--- a/overlays/mysql-innodb-cluster.yaml
+++ b/overlays/mysql-innodb-cluster.yaml
@@ -1,13 +1,9 @@
-# Variables
-source:                     &source          __OS_ORIGIN__
-
 applications:
   mysql:  # we call it 'mysql' since that's how other applications address this one.
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__mysql-innodb-cluster
     constraints: mem=4G
     num_units: __NUM_MYSQL_UNITS__  # min 3
     options:
-      source: *source
       innodb-buffer-pool-size: 50%
       max-connections: 20000
       tuning-level: fast

--- a/overlays/rabbitmq-source.yaml
+++ b/overlays/rabbitmq-source.yaml
@@ -1,0 +1,19 @@
+# rabbitmq-server is only in the trusty-mitaka and xenial-queens cloud-archive
+#
+# The charm isn't always updated with the latest release (e.g. jammy-zed) so
+# errors out if we set it unconditionally.
+#
+# For jammy onwards we can expect the charmhub channel to setup any required
+# source, but to maintain backwards compatability with trusty-mitaka and
+# xenial-queens we need to set source on those releases
+#
+# We do that here in an overlay so that the config value is not set at all on
+# jammy and uses the charm default
+
+# Variables
+source:                     &source                    __SOURCE__
+
+applications:
+  rabbitmq-server:
+    options:
+      source: __SOURCE__


### PR DESCRIPTION
Add jammy-zed support by specifying the zed-specific 22.09 OVN release
