### PR TITLE
Fix target helper for victoria series

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -639,6 +639,10 @@ do
         --cinder-lvm)
             assert_min_release queens 'cinder-lvm'
             MOD_OVERLAYS+=( "cinder-lvm.yaml" )
+            if has_min_release wallaby; then
+              MOD_OVERLAYS+=( "cinder-lvm-wallaby.yaml" )
+            fi
+
             ;;
         --cinder-volume)
             assert_min_release ussuri 'cinder-volume'

--- a/overlays/cinder-lvm-wallaby.yaml
+++ b/overlays/cinder-lvm-wallaby.yaml
@@ -1,0 +1,5 @@
+applications:
+  cinder-lvm:
+    options:
+      # https://bugs.launchpad.net/charm-cinder-lvm/+bug/1949074
+      config-flags: target_helper=lioadm

--- a/overlays/cinder-lvm.yaml
+++ b/overlays/cinder-lvm.yaml
@@ -4,8 +4,6 @@ applications:
     options:
       allocation-type: auto
       block-device: /dev/vdb
-      # https://bugs.launchpad.net/charm-cinder-lvm/+bug/1949074
-      config-flags: target_helper=lioadm
   __CINDER_VOLUME_INTERFACE__:
     storage:
       block-devices: 'cinder,40G,1'


### PR DESCRIPTION
The target_helper lioadm was only introduced as default in wallaby. So, older versions don't have it. See
https://bugs.launchpad.net/charm-cinder-lvm/+bug/1949074 for more info