### PR TITLE
mysql-innodb-cluster: no SSL by default

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -371,15 +371,15 @@ do
                 MOD_OVERLAYS+=( "vault-openstack-certificates-masakari.yaml" )
             fi
             ;;
+        --mysql-innodb-cluster-ssl)
+            MOD_OVERLAYS+=( "vault-certificates-mysql-innodb-cluster.yaml" )
+            ;;
         --mysql-innodb-cluster*)
             conflicts_with $1 --mysql-ha*
             assert_min_release train mysql-innodb-cluster
             # NOTE: 3 is actually the absolute minimum units required
             get_units $1 __NUM_MYSQL_UNITS__ 3
             MOD_OVERLAYS+=( "mysql-innodb-cluster.yaml")
-            if has_opt --vault; then
-                MOD_OVERLAYS+=( "vault-certificates-mysql-innodb-cluster.yaml" )
-            fi
             # this will be auto-generated for each app (see common/render.d/all)
             MOD_OVERLAYS+=( "mysql-innodb-cluster-router.yaml" )
             MOD_PARAMS[__MYSQL_INTERFACE__]='__APPLICATION_MYSQL_INNODB_ROUTER__'


### PR DESCRIPTION
Don't use vault certificates by default with MySQL InnoDB Cluster.

The certificates aren't setup until you unlock the vault, which you
can't do until halfway through the charm deployment after MySQL has
already started since vault itself depends on MySQL.

When you unlock it, the certificates are created and the MySQL charm
then reconfigures and restarts MySQL which causes any OpenStack service
that is doing database migration/setup to fail and error out
permanently.

In my experience, this happens most of the time in practice.

We're not normally using this for real deployments, so add the
--mysql-innodb-cluster-ssl option to opt-in instead.
