### PR TITLE
neutron-ext-net: Customise physical network

### DIFF
--- a/openstack/bin/neutron-ext-net
+++ b/openstack/bin/neutron-ext-net
@@ -46,6 +46,10 @@ if __name__ == '__main__':
     parser.add_option("--network-type",
                       help="Network type.",
                       dest="network_type", action="store", default='gre')
+    parser.add_option("--physical-network",
+                      help="Physical network.",
+                      dest="physical_network", action="store", default='physnet1')
+
     (opts, args) = parser.parse_args()
 
     if len(args) != 1:
@@ -111,9 +115,9 @@ if __name__ == '__main__':
             network_msg['network']['provider:segmentation_id'] = 1234
         elif opts.network_type == 'vlan':
             network_msg['network']['provider:segmentation_id'] = 2
-            network_msg['network']['provider:physical_network'] = 'physnet1'
+            network_msg['network']['provider:physical_network'] = physical_network
         elif opts.network_type == 'flat':
-            network_msg['network']['provider:physical_network'] = 'physnet1'
+            network_msg['network']['provider:physical_network'] = physical_network
         else:
             network_msg['network']['provider:segmentation_id'] = 2
 

--- a/openstack/bin/neutron-ext-net-ksv3
+++ b/openstack/bin/neutron-ext-net-ksv3
@@ -41,6 +41,9 @@ if __name__ == '__main__':
     parser.add_option("--vlan-id",
                       help="Vlan_id",
                       dest="vlan_id", action="store", default='2')
+    parser.add_option("--physical-network",
+                      help="Physical network.",
+                      dest="physical_network", action="store", default='physnet1')
     (opts, args) = parser.parse_args()
 
     if len(args) != 1:
@@ -99,9 +102,9 @@ if __name__ == '__main__':
             network_msg['network']['provider:segmentation_id'] = 1234
         elif opts.network_type == 'vlan':
             network_msg['network']['provider:segmentation_id'] = opts.vlan_id
-            network_msg['network']['provider:physical_network'] = 'physnet1'
+            network_msg['network']['provider:physical_network'] = opts.physical_network
         elif opts.network_type == 'flat':
-            network_msg['network']['provider:physical_network'] = 'physnet1'
+            network_msg['network']['provider:physical_network'] = opts.physical_network
         else:
             network_msg['network']['provider:segmentation_id'] = 2
 


### PR DESCRIPTION
Give neutron-ext-net the ability to choose which physical network you
want to use.

Useful when replicating environments with multiple physical
networks including SR-IOV bonding environments.
