### PR TITLE
Fix ha overlays

### DIFF
--- a/openstack/module_defaults
+++ b/openstack/module_defaults
@@ -49,6 +49,7 @@ MOD_PARAMS[__OVERLAY_NETWORK_TYPE__]='vxlan'
 MOD_PARAMS[__MYSQL_INTERFACE__]='mysql:shared-db'
 MOD_PARAMS[__MAAS_URL__]=  # e.g. http://1.2.3.4:5240/MAAS
 MOD_PARAMS[__MAAS_API_KEY__]=
+MOD_PARAMS[__VIP_IFACE__]='ens3'
 
 # This is enough for creating one ubuntu vm or multiple cirros vms but some
 # scenarios may want to allow more per compute (e.g. octavia).

--- a/overlays/barbican-ha.yaml
+++ b/overlays/barbican-ha.yaml
@@ -2,6 +2,7 @@ applications:
   barbican:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   barbican-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/ceph-rgw-ha.yaml
+++ b/overlays/ceph-rgw-ha.yaml
@@ -2,6 +2,7 @@ applications:
   ceph-rgw:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   ceph-rgw-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/cinder-ha.yaml
+++ b/overlays/cinder-ha.yaml
@@ -2,6 +2,7 @@ applications:
   cinder:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   cinder-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/designate-ha.yaml
+++ b/overlays/designate-ha.yaml
@@ -2,6 +2,7 @@ applications:
   designate:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   designate-bind:
     num_units: 2
   designate-hacluster:

--- a/overlays/glance-ha.yaml
+++ b/overlays/glance-ha.yaml
@@ -2,6 +2,7 @@ applications:
   glance:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   glance-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/heat-ha.yaml
+++ b/overlays/heat-ha.yaml
@@ -2,6 +2,7 @@ applications:
   heat:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   heat-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/keystone-ha.yaml
+++ b/overlays/keystone-ha.yaml
@@ -2,6 +2,7 @@ applications:
   keystone:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   keystone-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/manila-ganesha-ha.yaml
+++ b/overlays/manila-ganesha-ha.yaml
@@ -2,6 +2,7 @@ applications:
   manila-ganesha:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   manila-ganesha-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/manila.yaml
+++ b/overlays/manila.yaml
@@ -21,6 +21,7 @@ applications:
       default-share-backend: cephfsnfs1
       share-protocols: NFS
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   manila-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/masakari-ha.yaml
+++ b/overlays/masakari-ha.yaml
@@ -2,6 +2,7 @@ applications:
   masakari:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   masakari-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/mysql-ha.yaml
+++ b/overlays/mysql-ha.yaml
@@ -2,6 +2,7 @@ applications:
   mysql:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   mysql-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/neutron-api-ha.yaml
+++ b/overlays/neutron-api-ha.yaml
@@ -2,6 +2,7 @@ applications:
   neutron-api:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   neutron-api-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/nova-cloud-controller-ha.yaml
+++ b/overlays/nova-cloud-controller-ha.yaml
@@ -2,6 +2,7 @@ applications:
   nova-cloud-controller:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   nova-cloud-controller-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/octavia-ha.yaml
+++ b/overlays/octavia-ha.yaml
@@ -2,6 +2,7 @@ applications:
   octavia:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   octavia-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/openstack-dashboard-ha.yaml
+++ b/overlays/openstack-dashboard-ha.yaml
@@ -2,6 +2,7 @@ applications:
   openstack-dashboard:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   openstack-dashboard-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/placement-ha.yaml
+++ b/overlays/placement-ha.yaml
@@ -2,6 +2,7 @@ applications:
   placement:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   placement-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/swift-ha.yaml
+++ b/overlays/swift-ha.yaml
@@ -2,6 +2,7 @@ applications:
   swift-proxy:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   swift-proxy-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/telemetry-ha.yaml
+++ b/overlays/telemetry-ha.yaml
@@ -2,12 +2,15 @@ applications:
   ceilometer:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   aodh:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   gnocchi:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   ceilometer-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:

--- a/overlays/vault-ha.yaml
+++ b/overlays/vault-ha.yaml
@@ -2,6 +2,7 @@ applications:
   vault:
     options:
       vip: __VIP__
+      vip_iface: __VIP_IFACE__
   vault-hacluster:
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__hacluster
     options:


### PR DESCRIPTION
vip_iface is not being set, so it defaults to eth0, which fails on all ha openstack deployments. Setting it to default to ens3 fixes that.