### PR TITLE
add missing vault-kv relation to kubernetes-control-plane

### DIFF
--- a/overlays/k8s-vault-lb.yaml
+++ b/overlays/k8s-vault-lb.yaml
@@ -1,2 +1,4 @@
 relations:
  - ['kubeapi-load-balancer:certificates', 'vault:certificates']
+ - ['kubernetes-control-plane:vault-kv',  'vault:secrets']
+


### PR DESCRIPTION
Seems that the `kubernetes-control-plane` requires the `vault-kv` -> `vault:secrets` relation in order to configure the VIP IP of the vault and be able to connect to it properly.