### PR TITLE
Remove deprecated Kubernetes relation with Ceph

### DIFF
--- a/overlays/k8s-ceph.yaml
+++ b/overlays/k8s-ceph.yaml
@@ -1,3 +1,2 @@
 relations:
-  - [ 'kubernetes-control-plane:ceph-storage', 'ceph-mon:admin' ]
   - [ 'kubernetes-control-plane:ceph-client', __CEPH_INTERFACE__ ]


### PR DESCRIPTION
ceph-storage relation was deprecated on 1.24[1], so remove it.

Fixes #41

[1] https://ubuntu.com/kubernetes/docs/upgrade-notes#ceph-storage-relation-deprecated