### PR TITLE
lint-git-messages.sh: Fix line width detection

### DIFF
--- a/tools/lint-git-messages.sh
+++ b/tools/lint-git-messages.sh
@@ -56,7 +56,7 @@ for sha in $(git rev-list --no-merges ${base_commit}..${head_commit}); do
             exit 1
         fi
         for i in $(seq 2 $(( ${#message[@]} - 1 ))); do
-            if [[ ${#message[${i}]} > 72 ]]; then
+            if [[ ${#message[${i}]} -gt 72 ]]; then
                 echo "[ERROR] Body line is > 72 characters"
                 echo "  ${message[${i}]}"
                 exit 1


### PR DESCRIPTION
The body line width detector was using the '>' comparison which is meant
for strings, not integers. In practice it was failing on a 9 character
wide line.

Switch to the correct "-gt" integer check.
