### PR TITLE
Add lunar/antelope support

### DIFF
--- a/common/ch_channel_map/any_series
+++ b/common/ch_channel_map/any_series
@@ -1,5 +1,9 @@
+# newer openstack release names map to a release number
+declare -A RELNAME_MAP=(
+    [antelope]=2023.1
+)
 for c in ${OST_CHARMS[@]}; do
-    CHARM_CHANNEL[$c]=$release/edge
+    CHARM_CHANNEL[$c]=${RELNAME_MAP[$release]:-$release}/edge
 done
 
 for c in ${CEPH_CHARMS[@]}; do

--- a/common/ch_channel_map/lunar
+++ b/common/ch_channel_map/lunar
@@ -1,0 +1,16 @@
+# These are charmhub mappings for charms that are outside of the main large
+# groupings like openstack and ceph etc.
+
+# Versions are based on https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html
+
+# "Charm Delivery" specifies vault 1.8 for jammy, however field have actually been using 1.7.
+# Stick with 1.7 to more closely replicate customer deployments.
+CHARM_CHANNEL[vault]=latest/edge
+
+CHARM_CHANNEL[rabbitmq-server]=latest/edge
+CHARM_CHANNEL[mysql-router]=latest/edge
+CHARM_CHANNEL[mysql-innodb-cluster]=latest/edge
+CHARM_CHANNEL[hacluster]=2.4/edge
+CHARM_CHANNEL[ovn-central]=latest/edge
+CHARM_CHANNEL[ovn-chassis]=latest/edge
+CHARM_CHANNEL[ovn-dedicated-chassis]=latest/edge

--- a/common/helpers
+++ b/common/helpers
@@ -1,6 +1,7 @@
 #!/bin/bash
 declare -a CACHED_STDIN=( $@ )
 declare -A MASTER_OPTS=(
+    [DEFAULT_CHANNEL]=edge
     [DEFAULT_BINDING]=
     [HYPERCONVERGED_DEPLOYMENT]=false
     [MODEL_CONFIG]=''
@@ -461,7 +462,7 @@ assert_min_release ()
     local r=`get_release`
 
     [ -n "$r" ] || r=${lts[`get_series ${CACHED_STDIN[@]}`]:-${nonlts[`get_series ${CACHED_STDIN[@]}`]:-""}}
-    [[ "$r" < "$min" ]] || return 0
+    (( ${os_releases[$r]} < ${os_releases[$min]} )) || return 0
     echo "Min release '$min' required to be able to use $feature_name (currently using '$r')" 1>&2
     exit 1
 }
@@ -578,7 +579,9 @@ ost_series_autocorrect ()
         num_rels=${#lts_releases_sorted[@]}
         newseries=""
         for r in ${lts_releases_sorted[@]}; do
-            if [[ "$release" > "$r" ]]; then
+            a=${os_releases[$release]}
+            b=${os_releases[$r]}
+            if (( $a > $b )); then
                 newseries=${lts_rev[$r]}
                 break
             fi
@@ -618,7 +621,7 @@ get_app_release_name ()
     local ubuntu_release="$1"
     local release_name=
 
-    [ -n "$release" ] || return 0
+    [ -n "$ubuntu_release" ] || return 0
     readarray -t names_sorted_asc<<<"`echo ${!APP_RELEASE_NAMES[@]}| \
                                             tr ' ' '\n'| sort`"
     for name in ${names_sorted_asc[@]}; do

--- a/common/openstack_release_info
+++ b/common/openstack_release_info
@@ -25,8 +25,23 @@ declare -A lts=( [trusty]=icehouse
 declare -A nonlts=( [hirsute]=wallaby
                     [impish]=xena
                     [kinetic]=zed
+                    [lunar]=antelope
 )
-
+# NOTE: must be kept upt-to-date with all supported (non-eol) versions of openstack
+declare -A os_releases=( [icehouse]=0
+                         [mitaka]=1
+                         [queens]=2
+                         [rocky]=3
+                         [stein]=4
+                         [train]=5
+                         [ussuri]=6
+                         [victoria]=7
+                         [wallaby]=8
+                         [xena]=9
+                         [yoga]=10
+                         [zed]=11
+                         [antelope]=12
+)
 # Reverse lookups (revision to series)
 declare -A lts_rev=()
 for s in ${!lts[@]}; do

--- a/common/render.d/all
+++ b/common/render.d/all
@@ -11,7 +11,6 @@ render_mod_params ()
     declare -A CHANNEL_DEFAULT=( [cs:]=stable [ch:]=latest/stable )
     local store=${MASTER_OPTS[CHARM_STORE]}
     local store_default_channel=${CHANNEL_DEFAULT[$store]}
-    local service_default_channel=${MASTER_OPTS[DEFAULT_CHANNEL]:-$store_default_channel}
     local channel
 
     local charms
@@ -25,7 +24,7 @@ render_mod_params ()
     for c in ${charms[@]}; do
         if [[ $store == "ch:" ]]; then
             # apply channel and prefix, if required, for each charm
-            channel=${CHARM_CHANNEL[$c]:-$service_default_channel}
+            channel=${CHARM_CHANNEL[$c]:-$store_default_channel}
             echo "-e '/__CHARM_CS_NS____CHARM_CH_PREFIX__${c}\s*$/a\ \ \ \ channel: $channel'" >> $config_renderer
             echo "-e '/__CHARM_CS_NS____CHARM_CH_PREFIX__${c}\s*$/a\ \ \ \ series: ${series}'" >> $config_renderer
 


### PR DESCRIPTION
Due to some checks being done by alphabetical order, it would break how we would assign and ensure that minimal versions of certain charms are installed in certain openstack versions.
How I approach the fix is by putting all the relevant openstack versions in an ordered array so that we can compare numerically the openstack versions between eachother.

Closes: #112 