### PR TITLE
Add ocata to openstack_release_info

### DIFF
--- a/common/openstack_release_info
+++ b/common/openstack_release_info
@@ -30,17 +30,18 @@ declare -A nonlts=( [hirsute]=wallaby
 # NOTE: must be kept upt-to-date with all supported (non-eol) versions of openstack
 declare -A os_releases=( [icehouse]=0
                          [mitaka]=1
-                         [queens]=2
-                         [rocky]=3
-                         [stein]=4
-                         [train]=5
-                         [ussuri]=6
-                         [victoria]=7
-                         [wallaby]=8
-                         [xena]=9
-                         [yoga]=10
-                         [zed]=11
-                         [antelope]=12
+                         [ocata]=2
+                         [queens]=3
+                         [rocky]=4
+                         [stein]=5
+                         [train]=6
+                         [ussuri]=7
+                         [victoria]=8
+                         [wallaby]=9
+                         [xena]=10
+                         [yoga]=11
+                         [zed]=12
+                         [antelope]=13
 )
 # Reverse lookups (revision to series)
 declare -A lts_rev=()


### PR DESCRIPTION
This is necessary due to minimum release requirements for designate.

Closes: #114