### PR TITLE
Switch to stable channel for bionic and jammy

### DIFF
--- a/common/ch_channel_map/bionic
+++ b/common/ch_channel_map/bionic
@@ -3,7 +3,7 @@
 
 # Versions are based on https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html
 
-CHARM_CHANNEL[vault]=1.5/edge
-CHARM_CHANNEL[rabbitmq-server]=3.6/edge
-CHARM_CHANNEL[percona-cluster]=5.7/edge
-CHARM_CHANNEL[hacluster]=1.1.18/edge
+CHARM_CHANNEL[vault]=1.5/stable
+CHARM_CHANNEL[rabbitmq-server]=3.6/stable
+CHARM_CHANNEL[percona-cluster]=5.7/stable
+CHARM_CHANNEL[hacluster]=1.1.18/stable

--- a/common/ch_channel_map/jammy
+++ b/common/ch_channel_map/jammy
@@ -5,12 +5,12 @@
 
 # "Charm Delivery" specifies vault 1.8 for jammy, however field have actually been using 1.7.
 # Stick with 1.7 to more closely replicate customer deployments.
-CHARM_CHANNEL[vault]=1.7/edge
+CHARM_CHANNEL[vault]=1.7/stable
 
-CHARM_CHANNEL[rabbitmq-server]=3.9/edge
-CHARM_CHANNEL[mysql-router]=8.0/edge
-CHARM_CHANNEL[mysql-innodb-cluster]=8.0/edge
-CHARM_CHANNEL[hacluster]=2.4/edge
-CHARM_CHANNEL[ovn-central]=22.03/edge
-CHARM_CHANNEL[ovn-chassis]=22.03/edge
-CHARM_CHANNEL[ovn-dedicated-chassis]=22.03/edge
+CHARM_CHANNEL[rabbitmq-server]=3.9/stable
+CHARM_CHANNEL[mysql-router]=8.0/stable
+CHARM_CHANNEL[mysql-innodb-cluster]=8.0/stable
+CHARM_CHANNEL[hacluster]=2.4/stable
+CHARM_CHANNEL[ovn-central]=22.03/stable
+CHARM_CHANNEL[ovn-chassis]=22.03/stable
+CHARM_CHANNEL[ovn-dedicated-chassis]=22.03/stable


### PR DESCRIPTION
The mysql-router charm will not relate the shared-db relation on edge.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
