### PR TITLE
Update bionic versions

### DIFF
--- a/common/ch_channel_map/bionic
+++ b/common/ch_channel_map/bionic
@@ -4,7 +4,10 @@
 # Versions are based on https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html
 
 CHARM_CHANNEL[vault]=1.5/stable
-CHARM_CHANNEL[rabbitmq-server]=3.6/stable
+CHARM_CHANNEL[rabbitmq-server]=3.6/edge
 CHARM_CHANNEL[percona-cluster]=5.7/stable
 CHARM_CHANNEL[hacluster]=1.1.18/stable
 CHARM_CHANNEL[mongodb]=3.6/stable
+CHARM_CHANNEL[ovn-central]=20.03/stable
+CHARM_CHANNEL[ovn-chassis]=20.03/stable
+CHARM_CHANNEL[ovn-dedicated-chassis]=20.03/stable


### PR DESCRIPTION
OVN and Rabbitmq charm channels needed adjusting
to use versions that support Bionic.

Closes-Bug: #131