### PR TITLE
Remove hard-coded unit reference

### DIFF
--- a/openstack/novarc
+++ b/openstack/novarc
@@ -16,7 +16,7 @@ done
 
 keystone_addr=`juju config keystone vip`
 if [ -z "$keystone_addr" ]; then
-    keystone_addr=`jq -r '.applications.keystone.units."keystone/0"."public-address"' $juju_status_json_cache`
+    keystone_addr=$(jq --raw-output '.applications.keystone.units[] | select (.leader == true) | .["public-address"]' $juju_status_json_cache)
 fi
 
 # check config-based ssl first


### PR DESCRIPTION
When keystone unit 0 is missing or another unit is the current leader,
the hard-coded reference to `keystone/0` will yield a null or incorrect
result.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
