### PR TITLE
Make ovn provider non-optional

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -419,26 +419,24 @@ do
             if has_opt --openstack-dashboard*; then
                 MOD_OVERLAYS+=( "openstack/octavia-dashboard.yaml" )
             fi
-            # no amphora if using ovn provider
-            if ! has_opt --octavia-ovn-provider; then
-                MOD_PARAMS[__AMPHORA_SSH_PUB_KEY__]="`get_amphora_ssh_pub_key`"
-                # This equates to m1.large (rather than m1.medium) which should
-                # allow creating 1x ubunu vm + 1x amphora vm on the same host thus
-                # avoiding the need for > 1 compute host.
-                MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=8G"
-                if ! has_opt --no-octavia-diskimage-retrofit; then
-                    # By default we let retrofit use images uploaded by the post-deploy configure script.
-                    MOD_OVERLAYS+=( "openstack/octavia-diskimage-retrofit.yaml" )
-                    MOD_PARAMS[__OCTAVIA_RETROFIT_UCA__]=`get_ost_release`
-                    if ! has_opt --octavia-diskimage-retrofit-glance-simplestreams; then
-                       MOD_OVERLAYS+=( "openstack/octavia-diskimage-retrofit-glance.yaml" )
-                    fi
+            MOD_PARAMS[__AMPHORA_SSH_PUB_KEY__]="`get_amphora_ssh_pub_key`"
+            # This equates to m1.large (rather than m1.medium) which should
+            # allow creating 1x ubunu vm + 1x amphora vm on the same host thus
+            # avoiding the need for > 1 compute host.
+            MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=8G"
+            if ! has_opt --no-octavia-diskimage-retrofit; then
+                # By default we let retrofit use images uploaded by the
+                # post-deploy configure script.
+                MOD_OVERLAYS+=( "openstack/octavia-diskimage-retrofit.yaml" )
+                MOD_PARAMS[__OCTAVIA_RETROFIT_UCA__]=`get_ost_release`
+                if ! has_opt --octavia-diskimage-retrofit-glance-simplestreams; then
+                   MOD_OVERLAYS+=( "openstack/octavia-diskimage-retrofit-glance.yaml" )
                 fi
-                MOD_MSGS[octavia.0]="you need to to create an amphora image before you can use Octavia"
-                MOD_MSGS[octavia.1]="this can be done in one of two ways:"
-                MOD_MSGS[octavia.2]="run ./tools/upload_octavia_amphora_image.sh --release $release to use a pre-created image (recommended)"
-                MOD_MSGS[octavia.3]="create a new image with 'juju $JUJU_RUN_CMD octavia-diskimage-retrofit/0 retrofit-image source-image=<uuid>' with id of image in Glance to use as base"
             fi
+            MOD_MSGS[octavia.0]="you need to to create an amphora image before you can use Octavia"
+            MOD_MSGS[octavia.1]="this can be done in one of two ways:"
+            MOD_MSGS[octavia.2]="run ./tools/upload_octavia_amphora_image.sh --release $release to use a pre-created image (recommended)"
+            MOD_MSGS[octavia.3]="create a new image with 'juju $JUJU_RUN_CMD octavia-diskimage-retrofit/0 retrofit-image source-image=<uuid>' with id of image in Glance to use as base"
             if has_opt --octavia-ipv4; then
                 MOD_MSGS[octavia.4]="run tools/create_ipv4_octavia.sh"
             fi
@@ -449,13 +447,11 @@ do
             MOD_MSGS[octavia.9]="create loadbalancer i.e. ./tools/create_octavia_lb.sh --member-vm <uuid from prev step>"
             MOD_MSGS[octavia.10]="alternatively manually create loadbalancer"
             MOD_MSGS[octavia.11]="openstack loadbalancer create --name lb2 --vip-network-id lb-mgmt"
-            ;;
-        --octavia-ovn-provider)
-            MOD_OVERLAYS+=( "openstack/octavia-ovn-provider.yaml" )
-            assert_min_release victoria octavia-ovn-provider
-            # ensure octavia and ovn
-            set -- $@ --octavia && cache $@
-            set -- $@ --ml2-ovn && cache $@
+            if has_min_release victoria; then
+                if is_ml2_ovn; then
+                    MOD_OVERLAYS+=( "openstack/octavia-ovn-provider.yaml" )
+                fi
+            fi
             ;;
         --octavia-ha*)
             get_units $1 __NUM_OCTAVIA_UNITS__ 3


### PR DESCRIPTION
This change enables the ovn-provider for Octavia mandatory if at least
Victoria and OVN.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
