### PR TITLE
Separate relations into separate yaml document

### DIFF
--- a/openstack/openstack.yaml.template
+++ b/openstack/openstack.yaml.template
@@ -79,6 +79,7 @@ applications:
       ssl_ca: *ssl_ca
       ssl_cert: *ssl_cert
       ssl_key: *ssl_key
+---
 relations:
   - [ nova-cloud-controller:shared-db, __MYSQL_INTERFACE__ ]
   - [ nova-cloud-controller:amqp, rabbitmq-server ]

--- a/tools/juju-bundle-applications.py
+++ b/tools/juju-bundle-applications.py
@@ -7,8 +7,8 @@ application_list = set()
 
 for filename in sys.argv[1:]:
     with open(filename, 'r') as f:
-        data = yaml.load(f, Loader=yaml.SafeLoader)
-        if 'applications' in data:
-            application_list.update(data['applications'].keys())
-
+        data = yaml.load_all(f, Loader=yaml.SafeLoader)
+        for d in data:
+            if 'applications' in d:
+                application_list.update(d['applications'].keys())
 print('\n'.join(application_list))


### PR DESCRIPTION
To adjust to new juju 3.2 behaviour that does not
allow relations referencing overlay applications
in the base bundle.

Ref: https://bugs.launchpad.net/juju/+bug/2041785

Resolves: #149