### PR TITLE
Change systemd-resolve for resolvectl

### DIFF
--- a/common/helpers
+++ b/common/helpers
@@ -825,7 +825,13 @@ print_msgs ()
 
 get_local_upstream_dns ()
 {
-    local server="`systemd-resolve --status 2>/dev/null| sed -r 's/\s+DNS Servers:\s+([[:digit:]]+)/\1/g;t;d'| head -n 1`"
+    # Use old resolve command if present
+    if [ -f /usr/bin/systemd-resolve ]; then
+        local resolver="systemd-resolve --status"
+    else
+        local resolver="resolvectl"
+    fi
+    local server="`$resolver 2>/dev/null| sed -r 's/\s+DNS Servers:\s+([[:digit:]]+)/\1/g;t;d'| head -n 1`"
     (($?==0)) && echo $server && return 0
     echo "10.198.200.1"  # stsstack upstream dns
 }

--- a/common/helpers
+++ b/common/helpers
@@ -825,14 +825,13 @@ print_msgs ()
 
 get_local_upstream_dns ()
 {
-    # Use old resolve command if present
-    if [ -f /usr/bin/systemd-resolve ]; then
-        local resolver="systemd-resolve --status"
+    # Use old systemd-resolve command if present
+    if command -v systemd-resolve > /dev/null; then
+        local server=$(systemd-resolve --status 2> /dev/null | sed --regexp-extended 's/\s*DNS Servers:\s+([[:digit:]]+)/\1/g;t;d'| head -n 1)
     else
-        local resolver="resolvectl"
+        local server=$(resolvectl 2> /dev/null | sed --regexp-extended 's/\s*Current DNS Server:\s+([[:digit:]]+)/\1/g;t;d')
     fi
-    local server="`$resolver 2>/dev/null| sed -r 's/\s+DNS Servers:\s+([[:digit:]]+)/\1/g;t;d'| head -n 1`"
-    (($?==0)) && echo $server && return 0
+    (($? == 0)) && echo $server && return 0
     echo "10.198.200.1"  # stsstack upstream dns
 }
 


### PR DESCRIPTION
The `systemd-resolve` tool has been renamed to `resolvectl` in [systemd 239](https://github.com/systemd/systemd/blob/main/NEWS#L8539). 
From Jammy onwards the symlink `systemd-resolve` has been deleted and this code does not work.
Focal has systemd 245 so this change in fact removes support for Bionic and adds support for Jammy and following releases. If support for Bionic is still desired the patch should be expanded.