### PR TITLE
Ignore errors when listing subnets

### DIFF
--- a/common/generate_bundle_base
+++ b/common/generate_bundle_base
@@ -12,10 +12,10 @@ update_master_opts ${MOD_PASSTHROUGH_OPTS[@]}
 vip_start=${MASTER_OPTS[VIP_ADDR_START]}
 if [[ -z $vip_start ]]; then
     # prodstack
-    cidr=$(source ~/novarc; openstack subnet show subnet_${OS_USERNAME} -c cidr -f value 2>/dev/null)
+    cidr=$(source ~/novarc; openstack subnet show subnet_${OS_USERNAME} -c cidr -f value 2>/dev/null || true)
     if [[ -z $cidr ]]; then
         # stsstack
-        cidr=$(source ~/novarc; openstack subnet show ${OS_USERNAME}_admin_subnet -c cidr -f value 2>/dev/null)
+        cidr=$(source ~/novarc; openstack subnet show ${OS_USERNAME}_admin_subnet -c cidr -f value 2>/dev/null || true)
     fi
     if [[ -n $cidr ]]; then
         vip_start=$(echo $cidr| sed -r 's/([0-9]+\.[0-9]+).+/\1/g').150.0


### PR DESCRIPTION
On STSStack, the first call to `openstack subnets` is expected to fail.
The script needs to ignore this failure.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
