### PR TITLE
Fix errors with control plane HA

### DIFF
--- a/kubernetes/pipeline/02configure
+++ b/kubernetes/pipeline/02configure
@@ -173,7 +173,6 @@ do
             fi
             get_units $1 __NUM_K8S_CONTROL_PLANE_UNITS__ 3
             MOD_OVERLAYS+=( "kubernetes/k8s-control-plane-ha.yaml" )
-            check_hacluster_channel
             ;;
         --vault)
             MOD_OVERLAYS+=( "vault.yaml" )

--- a/overlays/kubernetes/k8s-control-plane-ha.yaml
+++ b/overlays/kubernetes/k8s-control-plane-ha.yaml
@@ -8,4 +8,3 @@ applications:
       cluster_count: __NUM_K8S_CONTROL_PLANE_UNITS__
 relations:
   - [ kubernetes-control-plane-hacluster, kubernetes-control-plane ]
-  - [ kubernetes-control-plane:kube-api-endpoint, kubernetes-worker:kube-api-endpoint ]


### PR DESCRIPTION
Removing two lines that prevented a deployment of kubernetes with multiple kubernetes-control-pane units.