### PR TITLE
Fix SWIFT_IP for prodstack6

### DIFF
--- a/openstack/profiles/common
+++ b/openstack/profiles/common
@@ -10,7 +10,7 @@ function upload_image {
     image_arch=${5:-"x86_64"}
 
     case "$src" in
-        swift) http_root="http://$SWIFT_IP:80/swift/v1/images";;
+        swift) http_root="${SWIFT_URI}/swift/v1/images";;
         cloudimages) http_root="http://cloud-images.ubuntu.com/${image_name}/current";;
     esac
 

--- a/openstack/profiles/default
+++ b/openstack/profiles/default
@@ -6,7 +6,7 @@ install_packages
 
 # Set sts-stack overrides, if not already set.
 [[ -z "$NAMESERVER" ]] && export NAMESERVER="10.230.64.2"
-[[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.230.19.58"
+[[ -z "$SWIFT_URI" ]] && export SWIFT_URI="http://10.230.19.58"
 
 # Set defaults, if not already set.
 [[ -z "$GATEWAY" ]] && export GATEWAY="10.5.0.1"

--- a/openstack/profiles/prodstack6
+++ b/openstack/profiles/prodstack6
@@ -5,7 +5,7 @@ CIDR=`openstack subnet show subnet_$OS_USERNAME -c cidr -f value`
 ABC=${CIDR%%.0*}
 
 [[ -z "$NAMESERVER" ]] && export NAMESERVER="91.189.91.131"
-[[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.140.56.22"
+[[ -z "$SWIFT_URI" ]] && export SWIFT_URI="https://radosgw.ps6.canonical.com"
 
 # Set defaults, if not already set.
 [[ -z "$GATEWAY" ]] && export GATEWAY="$GATEWAY"

--- a/openstack/profiles/serverstack
+++ b/openstack/profiles/serverstack
@@ -2,7 +2,7 @@
 
 # serverstack overrides
 [[ -z "$NAMESERVER" ]] && export NAMESERVER="10.245.160.2"
-[[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"
+[[ -z "$SWIFT_URI" ]] && export SWIFT_URI="http://10.245.161.162"
 
 export UNDERCLOUD_NETWORK_NAME="$(sed -E --quiet "s/.+OS_PROJECT_NAME=(.+)/\1_admin_net/p" ~/novarc)"
 

--- a/openstack/profiles/stsstack
+++ b/openstack/profiles/stsstack
@@ -2,7 +2,7 @@
 
 # stsstack overrides
 [[ -z "$NAMESERVER" ]] && export NAMESERVER="10.230.64.2"
-[[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.230.19.58"
+[[ -z "$SWIFT_URI" ]] && export SWIFT_URI="http://10.230.19.58"
 
 export UNDERCLOUD_NETWORK_NAME="$(sed -E --quiet "s/.+OS_PROJECT_NAME=(.+)/\1_admin_net/p" ~/novarc)"
 

--- a/openstack/tools/upload_octavia_amphora_image.sh
+++ b/openstack/tools/upload_octavia_amphora_image.sh
@@ -5,6 +5,7 @@
 
 declare release=
 declare image_format=
+declare profile=stsstack
 
 scriptpath=$(readlink --canonicalize $(dirname $0))
 
@@ -18,15 +19,20 @@ while (( $# > 0 )); do
             image_format=$2
             shift
             ;;
+        --profile)
+            profile=$2
+            shift
+            ;;
         --help|-h)
             cat <<EOF
 Usage:
 
-./tools/upload_octavia_amphora_image.sh --release RELEASE [--image-format FORMAT]
+./tools/upload_octavia_amphora_image.sh [--profile PROFILE] --release RELEASE [--image-format FORMAT]
 
 Options:
 
 --help | -h             This help
+--profile               Profile {stsstack, prodstack6, serverstack}
 --release | -r          The OpenStack release
 --image-format | -f     The image format {'qcow2', 'raw'}. The default
                         is qcow2.
@@ -56,7 +62,7 @@ ts=`sed -r "s/.+-([[:digit:]]+)-$release.+/\1/g;t;d" $tmp| sort -h| tail -n 1`
 img="`egrep "${ts}.+$release" $tmp| tail -n 1`"
 rm $tmp
 
-export SWIFT_IP="10.230.19.58"
+eval $(grep SWIFT_URI openstack/profiles/${profile})
 source ${scriptpath}/../profiles/common
 source ${scriptpath}/../novarc
 upload_image swift octavia-amphora $img $image_format


### PR DESCRIPTION
On PS6 we have to use TLS for talking to radosgw (Swift). This change
updates the use of `SWIFT_IP` everywhere so that the protocol, http or
https, can be specified.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
