### PR TITLE
Replace Sh shell in shebang with Bash

### DIFF
--- a/jaas/configure
+++ b/jaas/configure
@@ -1,4 +1,4 @@
-#!/bin/sh -u
+#!/bin/bash -u
 
 status=$(juju status  --format=json)
 candid_haproxy_machine=$(echo $status | jq '.applications."candid-haproxy".units."candid-haproxy/0".machine')

--- a/openstack/configure
+++ b/openstack/configure
@@ -1,4 +1,4 @@
-#!/bin/sh -u
+#!/bin/bash -u
 profile=${1:-prodstack6}
 net_type=${2:-""}
 ./profiles/$profile $net_type


### PR DESCRIPTION
These two scripts still used Sh shell in shebang. In some situations, it was an issue when they sourced Bash specific scripts (directly or indirectly)

See PR #208 for details