### PR TITLE
Add root-disk constraint to nova-compute

### DIFF
--- a/openstack/module_defaults
+++ b/openstack/module_defaults
@@ -54,7 +54,7 @@ MOD_PARAMS[__PATH_MTU__]=
 
 # This is enough for creating one ubuntu vm or multiple cirros vms but some
 # scenarios may want to allow more per compute (e.g. octavia).
-MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=4G"
+MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=4G root-disk=80G"
 
 # Try to use current model (or newly requested one) as subdomain name
 model_subdomain=`get_juju_model`

--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -421,7 +421,7 @@ do
             # This equates to m1.large (rather than m1.medium) which should
             # allow creating 1x ubunu vm + 1x amphora vm on the same host thus
             # avoiding the need for > 1 compute host.
-            MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=8G"
+            MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=8G root-disk=80G"
             if ! has_opt --no-octavia-diskimage-retrofit; then
                 # By default we let retrofit use images uploaded by the
                 # post-deploy configure script.


### PR DESCRIPTION
On PS6 we get a flavor with a disk of 20G if we do not constrain the
root-disk. This will break launching a jammy server for example because
it requires a 20G disk.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
