### PR TITLE
Add a script to allocate VIPs in PS6

### DIFF
--- a/common/generate_bundle_base
+++ b/common/generate_bundle_base
@@ -23,9 +23,8 @@ if [[ -z $vip_start ]] && [[ -e ~/novarc ]]; then
         # Our primary network is /25 and we are arbitrarily using the
         # last 20 addresses for vips which is prone to collisions but
         # we have no alternative currently.
-        net_start=$(awk -F'.' '/HostMin/{print $NF}' <<<$(ipcalc -b $cidr))
-        net_start_suffix=${net_start##*\.}
-        vip_start=$(echo $cidr| sed -r 's/([0-9]+\.[0-9]+\.[0-9]+).+/\1/g').$((net_start_suffix + 105))
+        net_end=$(awk -F'.' '/HostMax/{print $NF}' <<<$(ipcalc -b $cidr))
+        vip_start=$(echo $cidr| sed -r 's/([0-9]+\.[0-9]+\.[0-9]+).+/\1/g').$((net_end - 19))
     fi
 fi
 VIP_START_PREFIX=${vip_start%\.*}

--- a/openstack/tools/allocate_vips.sh
+++ b/openstack/tools/allocate_vips.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Allocate the last 20 IP addresses, which could be considered for
+# VIPs in OpenStack
+
+source ~/novarc
+num_vips=20
+subnet="subnet_${OS_USERNAME}-psd"
+
+cidr=$(openstack subnet show ${subnet} -c cidr -f value 2>/dev/null)
+
+net_end=$(awk -F'.' '/HostMax/{print $NF}' <<<$(ipcalc -b $cidr))
+
+vip_start_suffix=$((net_end - num_vips + 1))
+net_pre=$(echo $cidr| sed -r 's/([0-9]+\.[0-9]+\.[0-9]+).+/\1/g')
+
+j=1
+
+for i in $(seq ${vip_start_suffix} ${net_end})
+do
+    echo openstack port create --network net_${OS_USERNAME}-psd \
+        --fixed-ip subnet=subnet_${OS_USERNAME}-psd,ip-address=${net_pre}.$i \
+        --disable --os-cloud ps6 ps6-vip-ip$( printf "%02d" $j )
+    ((j++))
+done


### PR DESCRIPTION
This eneusres that these IP addresses don't get used by OpenStack and the relevant VIPs can be utilised and hence don't have conflicts