### PR TITLE
Force Juju to use Ceph for vm root disk

### DIFF
--- a/common/generate_bundle_base
+++ b/common/generate_bundle_base
@@ -42,6 +42,12 @@ if [ -n "${MASTER_OPTS[MODEL_CONFIG]}" ]; then
     juju model-config ${MASTER_OPTS[MODEL_CONFIG]}
 fi
 
+if [ -n "${MASTER_OPTS[MODEL_CONSTRAINTS]}" ]; then
+    juju set-model-constraints ${MASTER_OPTS[MODEL_CONSTRAINTS]}
+else
+    juju set-model-constraints root-disk-source=volume
+fi
+
 if has_opt --list; then
     state_root=`get_bundle_state_root`
     if [ -d "$state_root" ]; then

--- a/common/helpers
+++ b/common/helpers
@@ -5,6 +5,7 @@ declare -A MASTER_OPTS=(
     [DEFAULT_BINDING]=
     [HYPERCONVERGED_DEPLOYMENT]=false
     [MODEL_CONFIG]='test-mode=true'
+    [MODEL_CONSTRAINTS]=''
     [BUNDLE_NAME]=''
     [CLOUD_NAME]=''
     [TARGET_RELEASE_NAME]=''
@@ -178,6 +179,14 @@ filter_master_opts ()
                     MASTER_OPTS[MODEL_CONFIG]="$2"
                 else
                     MASTER_OPTS[MODEL_CONFIG]+=" $2"
+                fi
+                shift
+                ;;
+            --model-constraints)
+                if [ -z "${MASTER_OPTS[MODEL_CONSTRAINTS]}" ]; then
+                    MASTER_OPTS[MODEL_CONSTRAINTS]="$2"
+                else
+                    MASTER_OPTS[MODEL_CONSTRAINTS]+=" $2"
                 fi
                 shift
                 ;;


### PR DESCRIPTION
Adds a --model-constraints flag to override the default which is now to use a cinder/ceph volume for root disk.