### PR TITLE
Support dictionary type of bundle list

### DIFF
--- a/openstack/tools/identify_charm_func_tests.py
+++ b/openstack/tools/identify_charm_func_tests.py
@@ -9,12 +9,24 @@ import yaml
 CLASSIC_TESTS_YAML = 'tests/tests.yaml'
 REACTIVE_TESTS_YAML = os.path.join('src', CLASSIC_TESTS_YAML)
 
+def extract_values(bundle_list):
+    extracted = []
+    for item in bundle_list:
+        if isinstance(item, dict):
+            extracted.append(list(item.values())[0])
+        else:
+            extracted.append(item)
+    return extracted
+
 if os.path.exists(REACTIVE_TESTS_YAML):
     bundles = yaml.safe_load(open(REACTIVE_TESTS_YAML))
 else:
     bundles = yaml.safe_load(open(CLASSIC_TESTS_YAML))
 
-targets = set(bundles['smoke_bundles'] + bundles['gate_bundles'] +
-              bundles['dev_bundles'])
+smoke_bundles = extract_values(bundles['smoke_bundles'])
+gate_bundles = extract_values(bundles['gate_bundles'])
+dev_bundles = extract_values(bundles['dev_bundles'])
+
+targets = set(smoke_bundles + gate_bundles + dev_bundles)
 
 print(' '.join(sorted(targets)))


### PR DESCRIPTION
Previously, list type only is supported

//charm-manila-ganesha
gate_bundles:
- focal-xena
- focal-yoga
- jammy-yoga

dev_bundles: []

smoke_bundles:
- focal-yoga

// charm-mysql-router
gate_bundles:
- full_model_ha: focal-full-ha

dev_bundles:
- full_model_ha: jammy-full-ha

smoke_bundles:
- full_model_ha: focal-full-ha