### PR TITLE
default charmcraft_channel, TEST_VIP0X

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -90,8 +90,8 @@ OAM_MIN=$(ipcalc $CIDR_OAM| awk '$1=="HostMin:" {print $2}')
 OAM_MIN_ABC=${OAM_MIN%.*}
 OAM_MAX_D=${OAM_MAX##*.}
 # Picking last two addresses and hoping they dont get used by Neutron.
-export OS_VIP00=${OAM_MIN_ABC}.$(($OAM_MAX_D - 1))
-export OS_VIP01=${OAM_MIN_ABC}.$(($OAM_MAX_D - 2))
+export {OS,TEST}_VIP00=${OAM_MIN_ABC}.$(($OAM_MAX_D - 1))
+export {OS,TEST}_VIP01=${OAM_MIN_ABC}.$(($OAM_MAX_D - 2))
 
 # More information on config https://github.com/openstack-charmers/zaza/blob/master/doc/source/runningcharmtests.rst
 export {,TEST_}NET_ID=$(openstack network show net_${OS_USERNAME}-psd-extra -f value -c id)
@@ -113,7 +113,10 @@ export TEST_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack-charmer
 
 # 2. Build
 if ! $SKIP_BUILD; then
-    sudo snap refresh charmcraft --channel $(grep charmcraft_channel osci.yaml| sed -r 's/.+:\s+(\S+)/\1/')
+    # default value is 1.5/stable, assumed that later charm likely have charmcraft_channel value
+    CHARMCRAFT_CHANNEL=$(grep charmcraft_channel osci.yaml | sed -r 's/.+:\s+(\S+)/\1/') || CHARMCRAFT_CHANNEL="1.5/stable"
+
+    sudo snap refresh charmcraft --channel "$CHARMCRAFT_CHANNEL"
 
     # ensure lxc initialised
     lxd init --auto || true


### PR DESCRIPTION
charm func test runner: default charmcraft_channel

The charmcraft channel defaults to 1.5/stable [1], some charms omit
it from osci.yaml [2] so we need to implement a default.

[1] https://github.com/openstack-charmers/zosci-config/blob/master/roles/charm-build/defaults/main.yaml
[2] https://github.com/openstack/charm-glance-simplestreams-sync/blob/stable/yoga/osci.yaml

Adding TEST_VIP0x for some charms ( e.g charm-mysql-router )

[1] https://github.com/search?q=repo%3Aopenstack-charmers%2Fzaza-openstack-tests+TEST_VIP00&type=code