### PR TITLE
charm func test runner: fix broken target list

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -156,7 +156,7 @@ if [[ -n $FUNC_TEST_TARGET ]]; then
     func_targets[$FUNC_TEST_TARGET]=null
 else
     for target in $(python3 $TOOLS_PATH/identify_charm_func_tests.py); do
-        func_targets[target]=null
+        func_targets[$target]=null
     done
 fi
 


### PR DESCRIPTION
The list of test targets was always "target" instead of the actual list
of targets due to an accidentally ommited $-sign in #230 
