### PR TITLE
charm func test runner: default charmcraft_channel

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -129,7 +129,12 @@ export TEST_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack-charmer
 
 # 2. Build
 if ! $SKIP_BUILD; then
-    sudo snap refresh charmcraft --channel $(grep charmcraft_channel osci.yaml| sed -r 's/.+:\s+(\S+)/\1/')
+    CHARMCRAFT_CHANNEL=$(grep charmcraft_channel osci.yaml| sed -r 's/.+:\s+(\S+)/\1/')
+    if [ -z "${CHARMCRAFT_CHANNEL}" ]; then
+        CHARMCRAFT_CHANNEL=1.5/stable
+    fi
+
+    sudo snap refresh charmcraft --channel ${CHARMCRAFT_CHANNEL}
 
     # ensure lxc initialised
     lxd init --auto || true


### PR DESCRIPTION
The charmcraft channel defaults to 1.5/stable [1], some charms omit
it from osci.yaml [2] so we need to implement a default.

[1] https://github.com/openstack-charmers/zosci-config/blob/master/roles/charm-build/defaults/main.yaml
[2] https://github.com/openstack/charm-glance-simplestreams-sync/blob/stable/yoga/osci.yaml
