### PR TITLE
charm test runner: manual_functest and remote-build

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -40,7 +40,7 @@ OPTIONS:
         By default we wait before destroying the model after a test run. This
         flag can used to override that behaviour.
     --manual-functests
-        Runs functest commands separately (deploy,configure,test)instead of
+        Runs functest commands separately (deploy,configure,test) instead of
         the entire suite.
     --remote-build
         Builds the charm in a remote location and transfers the charm file over.

--- a/openstack/tools/func_test_tools/manual_functests_runner.sh
+++ b/openstack/tools/func_test_tools/manual_functests_runner.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+
+TARGET=$1
+SLEEP=$2
+
+if [[ ! -d ./.tox/func-noop ]]; then
+    tox -e func-noop
+fi
+
+juju add-model test-$TARGET --no-switch
+
+juju model-config -m test-$TARGET test-mode=true transmit-vendor-metrics=false enable-os-upgrade=false default-series=jammy automatically-retry-hooks=false
+
+source ./.tox/func-noop/bin/activate
+
+functest-deploy -b tests/bundles/$TARGET.yaml -m test-$TARGET
+
+juju status -m test-$TARGET
+
+functest-configure -m test-$TARGET
+
+juju status -m test-$TARGET
+
+echo "Sleeping for $SLEEP seconds"
+
+sleep $SLEEP
+
+echo "Woke up"
+
+juju status -m test-$TARGET
+
+functest-test -m test-$TARGET
+
+juju status -m test-$TARGET
+
+echo "Finished $TARGET"
+

--- a/openstack/tools/func_test_tools/manual_functests_runner.sh
+++ b/openstack/tools/func_test_tools/manual_functests_runner.sh
@@ -1,5 +1,20 @@
 #!/bin/bash -eu
 
+# This file assists the main charmed_functest_runner script but can also be invoked separately
+# by passing the target (jammy-antelope, focal-yoga, etc) to run and a sleep timer between the
+# configure and test run. If run manually, the .charm file must exist in the source code folder
+# and the environment variables need to have been exported prior to invoking this script.
+#
+# What this script does is run the functions functest-deploy, functest-configure and
+# functest-test separately one after the other, instead of the entire suite run in the
+# same command that the command functest-target does.
+#
+# The main advantages of this is that it is easier for debugging, and it can also help
+# when there are race conditions running the charm test (by using the sleep parameter).
+#
+# Ideally, all those issues should be worked out in zaza, but having this alternative
+# makes it easier for debugging, testing, and validating the race condition.
+
 TARGET=$1
 SLEEP=$2
 
@@ -8,6 +23,8 @@ if [[ ! -d ./.tox/func-noop ]]; then
 fi
 
 juju add-model test-$TARGET --no-switch
+
+# Those below are the parameters that are used when functest-target creates a model named "zaza-<hash>"
 
 juju model-config -m test-$TARGET test-mode=true transmit-vendor-metrics=false enable-os-upgrade=false default-series=jammy automatically-retry-hooks=false
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ bashfiles =
     {toxinidir}/openstack/tools/upload_octavia_amphora_image.sh
     {toxinidir}/openstack/tools/install_local_ca.sh
     {toxinidir}/openstack/tools/charmed_openstack_functest_runner.sh
+    {toxinidir}/openstack/tools/func_test_tools/manual_functests_runner.sh
     {toxinidir}/openstack/tools/instance_launch.sh
     {toxinidir}/openstack/tools/setup_tempest.sh
     {toxinidir}/openstack/tools/create_octavia_lb.sh


### PR DESCRIPTION
- Add support for remote-build for when the tests need to be run from a container due to python version
- Add support for manual functest runners (deploy, configure, test) for when the full suite fails requiring more granular approach (such as a sleep)