### PR TITLE
Add support for aliased zaza test targets

### DIFF
--- a/openstack/tools/func_test_tools/common.py
+++ b/openstack/tools/func_test_tools/common.py
@@ -1,0 +1,33 @@
+""" Common helpers for func test runners. """
+import os
+
+import yaml
+
+
+class OSCIConfig():
+    """ Extract information from osci.yaml """
+    def __init__(self):
+        if not os.path.exists('osci.yaml'):
+            self._osci_config = {}
+        else:
+            with open('osci.yaml', encoding='utf-8') as fd:
+                self._osci_config = yaml.safe_load(fd)
+
+    @property
+    def project_check_jobs(self):
+        """ Generator returning all project check jobs defined. """
+        for item in self._osci_config:
+            if 'project' not in item:
+                continue
+
+            if 'check' not in item['project']:
+                continue
+
+            yield from item['project']['check'].get('jobs', [])
+
+    @property
+    def jobs(self):
+        """ Generator returning all job definitions. """
+        for item in self._osci_config:
+            if 'job' in item:
+                yield item['job']

--- a/openstack/tools/func_test_tools/identify_charm_func_tests.py
+++ b/openstack/tools/func_test_tools/identify_charm_func_tests.py
@@ -5,8 +5,10 @@ run from within the charm root.
 Outputs space separated list of target names.
 """
 import os
+import re
 
 import yaml
+from common import OSCIConfig  # pylint: disable=import-error
 
 CLASSIC_TESTS_YAML = 'tests/tests.yaml'
 REACTIVE_TESTS_YAML = os.path.join('src', CLASSIC_TESTS_YAML)
@@ -27,19 +29,53 @@ def extract_targets(bundle_list):
     return extracted
 
 
-if __name__ == "__main__":
-    if os.path.exists(REACTIVE_TESTS_YAML):
-        TESTS_FILE = REACTIVE_TESTS_YAML
-    else:
-        TESTS_FILE = CLASSIC_TESTS_YAML
+def get_aliased_targets():
+    """
+    Extract aliased targets. A charm can define aliased targets which is where
+    Zaza tests are run and use configuration steps from an alias section rather
+    than the default (see 'configure:' section in tests.yaml for aliases). An
+    alias is run by specifying the target to be run as a tox command using a
+    job definition in osci.yaml where the target name has a <alias>: prefix.
 
-    with open(TESTS_FILE, encoding='utf-8') as fd:
+    We extract any aliased targets here and return as a list.
+    """
+    targets = []
+    osci = OSCIConfig()
+    for jobname in osci.project_check_jobs:
+        for job in osci.jobs:
+            if job['name'] != jobname:
+                continue
+
+            if 'tox_extra_args' not in job['vars']:
+                continue
+
+            ret = re.search(r"-- (\S+:\S+)",
+                            str(job['vars']['tox_extra_args']))
+            if ret:
+                targets.append(ret.group(1))
+
+    return targets
+
+
+def get_tests_bundles():
+    """
+    Extract test targets from primary location i.e. {src/}test/tests.yaml.
+    """
+    if os.path.exists(REACTIVE_TESTS_YAML):
+        tests_file = REACTIVE_TESTS_YAML
+    else:
+        tests_file = CLASSIC_TESTS_YAML
+
+    with open(tests_file, encoding='utf-8') as fd:
         bundles = yaml.safe_load(fd)
 
     smoke_bundles = extract_targets(bundles['smoke_bundles'])
     gate_bundles = extract_targets(bundles['gate_bundles'])
     dev_bundles = extract_targets(bundles['dev_bundles'])
+    return smoke_bundles + gate_bundles + dev_bundles
 
-    targets = set(smoke_bundles + gate_bundles + dev_bundles)
 
-    print(' '.join(sorted(targets)))
+if __name__ == "__main__":
+    aliased_bundles = get_aliased_targets()
+    tests_bundles = get_tests_bundles()
+    print(' '.join(sorted(set(tests_bundles + aliased_bundles))))

--- a/openstack/tools/func_test_tools/test_is_voting.py
+++ b/openstack/tools/func_test_tools/test_is_voting.py
@@ -7,7 +7,8 @@ Takes a func test target name as input.
 import os
 import sys
 
-import yaml
+from common import OSCIConfig  # pylint: disable=import-error
+
 
 if __name__ == "__main__":
     target_name = sys.argv[1]
@@ -16,11 +17,9 @@ if __name__ == "__main__":
                          f"{target_name} is voting.\n")
         sys.exit(0)
 
-    with open('osci.yaml', encoding='utf-8') as fd:
-        osci_config = yaml.safe_load(fd)
-
+    osci_config = OSCIConfig()
     try:
-        jobs = osci_config[0]['project']['check']['jobs']
+        jobs = osci_config.project_check_jobs
         if target_name in jobs:
             # default is voting=True
             sys.exit(0)


### PR DESCRIPTION
Zaza supports defining aliased configure sections such that a test can be run under an alias by prefixig the target name with <alias>: which will result in zaza using the alias configure section rather than the default. This adds support for extrating these aliased targets from oscsi.yaml.