### PR TITLE
Fixing the octavia-diskimage-retrofit

### DIFF
--- a/overlays/openstack/octavia-diskimage-retrofit-glance.yaml
+++ b/overlays/openstack/octavia-diskimage-retrofit-glance.yaml
@@ -1,6 +1,6 @@
 applications:
   glance:
-    constraints: mem=4G
+    constraints: mem=4G cores=4
 relations:
   - [ octavia-diskimage-retrofit:juju-info, glance:juju-info ]
 


### PR DESCRIPTION
The current configuration uses only 1 core CPU, and to be able to convert the images it's necessary to have at least 4 cores.