### PR TITLE
Support functest voting lookup fallback

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -110,6 +110,18 @@ done
 # Install dependencies
 snap info yq &>/dev/null || sudo snap install yq
 
+# Ensure zosic-config checked out and up-to-date
+(
+cd
+if [[ -d zosci-config ]]; then
+    cd zosci-config
+    git checkout master
+    git pull
+else
+    git clone https://github.com/openstack-charmers/zosci-config
+fi
+)
+
 TOOLS_PATH=$(realpath $(dirname $0))/func_test_tools
 CHARM_PATH=$(pwd)
 
@@ -182,8 +194,6 @@ if [[ -n $FUNC_TEST_PR ]]; then
     (
     [[ -d src ]] && cd src
     # We use the zosci-config tools to do this.
-    [[ -d ~/zosci-config ]] || ( cd; git clone https://github.com/openstack-charmers/zosci-config; )
-    (cd ~/zosci-config; git checkout master; git pull;)
     MSG=$(echo "Func-Test-Pr: https://github.com/openstack-charmers/zaza-openstack-tests/pull/$FUNC_TEST_PR"| base64)
     ~/zosci-config/roles/handle-func-test-pr/files/process_func_test_pr.py -f ./test-requirements.txt "$MSG"
     )

--- a/openstack/tools/func_test_tools/common.py
+++ b/openstack/tools/func_test_tools/common.py
@@ -31,3 +31,22 @@ class OSCIConfig():
         for item in self._osci_config:
             if 'job' in item:
                 yield item['job']
+
+
+class ProjectTemplatesConfig():
+    """ Extract information from project_templates.yaml """
+    def __init__(self, path):
+        if not os.path.exists(path):
+            self._config = {}
+        else:
+            with open(path, encoding='utf-8') as fd:
+                self._config = yaml.safe_load(fd)
+
+    @property
+    def project_templates(self):
+        """ Generator returning all project check jobs defined. """
+        for item in self._config:
+            if 'project-template' not in item:
+                continue
+
+            yield item['project-template']


### PR DESCRIPTION
If the target was not found in osci.yaml then osci will fallback to looking at
https://github.com/openstack-charmers/zosci-config/blob/master/zuul.d/project-templates.yaml