### PR TITLE
Reduce storage requirements of a default deployment

### DIFF
--- a/common/generate_bundle_base
+++ b/common/generate_bundle_base
@@ -51,7 +51,7 @@ fi
 if [ -n "${MASTER_OPTS[MODEL_CONSTRAINTS]}" ]; then
     juju set-model-constraints ${MASTER_OPTS[MODEL_CONSTRAINTS]}
 else
-    juju set-model-constraints root-disk-source=volume
+    juju set-model-constraints root-disk-source=volume root-disk=20G
 fi
 
 if has_opt --list; then

--- a/openstack/module_defaults
+++ b/openstack/module_defaults
@@ -54,7 +54,7 @@ MOD_PARAMS[__PATH_MTU__]=
 
 # This is enough for creating one ubuntu vm or multiple cirros vms but some
 # scenarios may want to allow more per compute (e.g. octavia).
-MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=4G root-disk=80G"
+MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=4G cores=2"
 
 # Try to use current model (or newly requested one) as subdomain name
 model_subdomain=`get_juju_model`

--- a/openstack/openstack.yaml.template
+++ b/openstack/openstack.yaml.template
@@ -35,6 +35,8 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack_origin
       force-raw-images: false  # disable for stsstack since conversion kills the disks and is not needed
+    storage:
+      ephemeral-device: cinder,50G,1
   nova-cloud-controller:
     num_units: __NUM_NOVACC_UNITS__
     charm: __CHARM_STORE____CHARM_CS_NS____CHARM_CH_PREFIX__nova-cloud-controller

--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -429,7 +429,7 @@ do
             # This equates to m1.large (rather than m1.medium) which should
             # allow creating 1x ubunu vm + 1x amphora vm on the same host thus
             # avoiding the need for > 1 compute host.
-            MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=8G root-disk=80G"
+            MOD_PARAMS[__NOVA_COMPUTE_UNIT_CONSTRAINTS__]="mem=8G cores=2"
             if ! has_opt --no-octavia-diskimage-retrofit; then
                 # By default we let retrofit use images uploaded by the
                 # post-deploy configure script.

--- a/overlays/openstack/vault-openstack-secrets.yaml
+++ b/overlays/openstack/vault-openstack-secrets.yaml
@@ -2,7 +2,5 @@ applications:
   nova-compute:
     options:
       encrypt: True
-    storage:
-      ephemeral-device: cinder,50G,1
 relations:
   - ['nova-compute:secrets-storage', 'vault:secrets']


### PR DESCRIPTION
Always deploy an 'ephemeral' storage disk for nova-compute, even if we are not 
using vault. While vault is pulled in by OVN in the majority of currently used
OpenStack versions, this will ensure we always have one of that size
regardless.

Remove the increased root-disk=80G size for nova-compute units, since we can 
use the space from the ephemeral disk instead.

Set a default root-disk=20GB constraint. Previously the prodstack6 environment 
would give us 20GB root disks as that is set in the default flavors, however
when booting from volume with root-disk-source=volume this is ignored and a
juju default of 30GB is used. Switch this to 20GB to go back to the previous
amount of storage.

With these changes the size of a jammy-yoga deployment with Ceph and 3x 
nova-compute nodes is reduced from 960GB to 600GB.

Closes: #229