### PR TITLE
Support tests.yaml bundles defined as None

### DIFF
--- a/openstack/tools/func_test_tools/identify_charm_func_tests.py
+++ b/openstack/tools/func_test_tools/identify_charm_func_tests.py
@@ -20,7 +20,7 @@ def extract_targets(bundle_list):
     value so this accounts for both formats.
     """
     extracted = []
-    for item in bundle_list:
+    for item in bundle_list or []:
         if isinstance(item, dict):
             extracted.append(list(item.values())[0])
         else:


### PR DESCRIPTION
Some tests.yaml files have bundles set to None so we need to protect against this.