### PR TITLE
The command 'juju show-cloud' does not support JSON format

### DIFF
--- a/common/helpers
+++ b/common/helpers
@@ -45,8 +45,8 @@ list_overlays ()
 
 get_cloud_type ()
 {
-   local cloud=$(juju show-model --format json |jq -r '[.[].cloud] | unique[]')
-   local type=$(juju show-cloud $cloud --format json | jq -r '[.[].type] | unique[]')
+   local cloud=`juju show-model| sed -rn 's/.+cloud:\s*(.+).*/\1/p'| uniq`
+   local type=`juju show-cloud $cloud| sed -rn 's/^type:\s*(.+).*/\1/p'| uniq`
    echo "$type"
 }
 


### PR DESCRIPTION
The PR #228 [1] changed to use jq instead of sed to parse yaml when relocating two lines. However, yaml format is not supported in versions prior to juju 3.x.

$ juju show-cloud localhost --format json
ERROR invalid value "json" for option --format: unknown format "json"

Therefore, we need to revert back to the previous two lines to support both juju 2.x and juju 3.x simultaneously.

[1] https://github.com/canonical/stsstack-bundles/pull/228