### PR TITLE
Ensure func tests log both stdout and stderr

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -288,5 +288,5 @@ for target in ${!func_targets[@]}; do
         echo "  * $target: FAILURE$voting_info"
     fi
 done
-) | tee $LOGFILE
+) 2>&1 | tee $LOGFILE
 echo -e "\nResults also saved to $LOGFILE"


### PR DESCRIPTION
Juju 2 prints output to stderr as opposed to stdout in Juju 3 so need to pipe both to logs.