### PR TITLE
Cleanup old zaza models

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -110,6 +110,15 @@ done
 # Install dependencies
 which yq &>/dev/null || sudo snap install yq
 
+# Cleanup zaza-* models before proceeding
+OLD_ZAZA_MODELS=$(juju list-models| grep -E "^zaza-\S+"|tr -d '*')
+if [ -n "${OLD_ZAZA_MODELS}" ]; then
+    echo "Old zaza-* models active, cleaning up."
+    for j in $(echo "${OLD_ZAZA_MODELS}"); do
+        juju destroy-model "${j}" --no-prompt --force --no-wait --destroy-storage
+    done
+fi
+
 # Ensure zosci-config checked out and up-to-date
 (
 cd


### PR DESCRIPTION
It can happen that when running the functests that the zaza model stays behind, either by cancelling the script or if the script has an error.

This patch adds a cleanup check to verify if there are old zaza-* models before proceeding to run the functests.