### PR TITLE
Respect project templates as defined in charm

### DIFF
--- a/openstack/tools/func_test_tools/identify_charm_func_test_jobs.py
+++ b/openstack/tools/func_test_tools/identify_charm_func_test_jobs.py
@@ -49,7 +49,8 @@ def get_default_jobs():
     c = configparser.ConfigParser()
     c.read('.gitreview')
     branch = c['gerrit']['defaultbranch']
-    jobs = ZOSCIConfig(path).get_branch_jobs(branch)
+    osci = OSCIConfig()
+    jobs = ZOSCIConfig(path).get_branch_jobs(branch, osci.project_templates)
     return jobs
 
 


### PR DESCRIPTION
Need to use the project template defined in the charm osci.yaml which will not always be the new/global
charm-functional-jobs.