### PR TITLE
Osci job vars tox target sometimes not dash prefixed

### DIFF
--- a/openstack/tools/func_test_tools/extract_job_target.py
+++ b/openstack/tools/func_test_tools/extract_job_target.py
@@ -21,7 +21,7 @@ def extract_job_target(testjob):
     if not job or 'vars' not in job or 'tox_extra_args' not in job['vars']:
         return testjob
 
-    ret = re.search(r"-- (.+)",
+    ret = re.search(r"(?:--)?\s*(.+)",
                     str(job['vars']['tox_extra_args']))
     if not ret:
         return testjob


### PR DESCRIPTION
The vars target arg sometimes does not contain the double dash so we have to support than when doing an extraction.