### PR TITLE
fix setting OS_AUTH_PROTOCOL to https

### DIFF
--- a/openstack/novarc
+++ b/openstack/novarc
@@ -40,8 +40,8 @@ END
                     return;;
             esac
         fi
+        export OS_AUTH_PROTOCOL=https
     fi
-    export OS_AUTH_PROTOCOL=https
 else
     unset OS_AUTH_PROTOCOL
 fi


### PR DESCRIPTION
The OS_AUTH_PROTOCOL should be set to 'https' only when a relation of type 'certificates' exists between keystone and vault. Before it was set when the the vault charm was found in the deployment.