### PR TITLE
Add member subnet option to script

### DIFF
--- a/openstack/tools/create_octavia_lb.sh
+++ b/openstack/tools/create_octavia_lb.sh
@@ -1,11 +1,15 @@
-#!/bin/bash -eux
+#!/bin/bash
+
+set -e -u
 
 lb=lb1
 declare -a member_vm=()
+member_subnet=
 provider=amphora
 protocol=HTTP
 protocol_port=80
 hm_protocol=
+vip_subnet=private_subnet
 
 while (( $# > 0 )); do
     case $1 in
@@ -23,6 +27,14 @@ while (( $# > 0 )); do
                 exit 1
             fi
             member_vm+=( "$2" )
+            shift
+            ;;
+        --member-subnet)
+            if (( $# < 2 )); then
+                echo "missing member subnet name or ID"
+                exit 1
+            fi
+            member_subnet=$2
             shift
             ;;
         --provider)
@@ -57,6 +69,14 @@ while (( $# > 0 )); do
             hm_protocol=$2
             shift
             ;;
+        --vip-subnet)
+            if (( $# < 2 )); then
+                echo "missing vip subnet name or ID"
+                exit 1
+            fi
+            vip_subnet=$2
+            shift
+            ;;
         -h|--help)
             cat <<EOF
 Usage:
@@ -70,6 +90,7 @@ $(basename "$0") [options]
 --provider PROVIDER      The Octavia provider {amphora, ovn}, default = ${provider}
 --protocol PROTOCOL      TCP, HTTP, ..., default = ${protocol}
 --protocol-port PORT     Port to use, default = ${protocol_port}
+--vip-subnet SUBNET      Name or ID of VIP subnet ${vip_subnet}
 EOF
             exit 0
             ;;
@@ -81,46 +102,50 @@ EOF
     shift
 done
 if [[ -z "$hm_protocol" ]]; then
-    hm_protocol=$protocol
+    hm_protocol=${protocol}
 fi
 url_path=
 if [[ ${hm_protocol} == HTTP ]]; then
     url_path="--url-path /"
 fi
 
-if openstack loadbalancer show ${lb} > /dev/null; then
-    echo "ERROR: a loadbalancer called $lb already exists"
+if openstack loadbalancer show ${lb} > /dev/null 2>&1; then
+    echo "ERROR: a loadbalancer called ${lb} already exists"
     exit 1
 fi
 
 LB_ID=$(openstack loadbalancer create \
     --name ${lb} \
-    --vip-subnet-id private_subnet \
+    --vip-subnet-id ${vip_subnet} \
     --provider ${provider} \
     --format value \
     --column id)
 
-# Re-run the following until $lb shows ACTIVE and ONLINE status':
-openstack loadbalancer show ${LB_ID}
-
 # wait for lb to be ACTIVE
+echo -n "waiting for $lb"
 while true; do
     if [[ $(openstack loadbalancer show ${LB_ID} --column provisioning_status --format value) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for $lb"
+    echo -n "."
+    sleep 2
 done
+echo
 
 LISTENER_ID=$(openstack loadbalancer listener create \
     --name ${lb}-listener --protocol ${protocol} --protocol-port ${protocol_port} \
-    --format value --column id $lb)
+    --format value --column id ${lb})
+
 # wait for listener to be ACTIVE
+echo -n "waiting for ${lb}-listener"
 while true; do
     if [[ $(openstack loadbalancer listener show ${LISTENER_ID} --column provisioning_status --format value) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for ${lb}-listener"
+    echo -n "."
+    sleep 2
 done
+echo
 
 LB_ALGORITHM=ROUND_ROBIN
 if [[ ${provider} == ovn ]]; then
@@ -132,18 +157,20 @@ POOL_ID=$(openstack loadbalancer pool create \
     --listener ${LISTENER_ID} \
     --protocol ${protocol} \
     --format value --column id)
-# wait for pool to be ACTIVE
+
+echo -n "waiting for ${lb}-pool"
 while true; do
     if [[ $(openstack loadbalancer pool show ${POOL_ID} --column provisioning_status --format value) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for ${lb}-pool"
+    echo -n "."
+    sleep 2
 done
+echo
 
 HM_ID=$(openstack loadbalancer healthmonitor create \
     --name ${lb}-healthmonitor --delay 5 --max-retries 4 --timeout 10 --type ${hm_protocol} ${url_path} ${POOL_ID} \
     --format value --column id)
-openstack loadbalancer healthmonitor list
 
 # Add vm(s) to pool
 if (( ${#member_vm[@]} == 0 )); then
@@ -155,24 +182,31 @@ if (( ${#member_vm[@]} == 0 )); then
 fi
 
 for member in "${member_vm[@]}"; do
-    netaddr=$(openstack port list --server ${member} --network private --column "Fixed IP Addresses" --format value | \
+    netaddr=$(openstack port list --server ${member} --column "Fixed IP Addresses" --format value | \
                 sed -rn -e "s/.+ip_address='([[:digit:]\.]+)',\s+.+/\1/" \
                         -e "s/.+ip_address':\s+'([[:digit:]\.]+)'}.+/\1/p")
-    member_id=$(openstack loadbalancer member create --subnet-id private_subnet \
-        --address $netaddr --protocol-port ${protocol_port} --format value --column id ${POOL_ID})
-    while true; do
-        [[ $(openstack loadbalancer member show --format value \
-            --column provisioning_status ${POOL_ID} ${member_id}) = ACTIVE ]] \
-            && break
-        echo "waiting for member ${member} (${member_id})"
-    done
-done
+    member_id=$(openstack loadbalancer member create --address ${netaddr} \
+                    $( [[ -n ${member_subnet} ]] && echo "--subnet-id ${member_subnet}" ) \
+                    --protocol-port ${protocol_port} --format value --column id ${POOL_ID})
 
-openstack loadbalancer member list ${POOL_ID}
+    echo -n "waiting for member ${member} (${member_id})"
+    while true; do
+        if [[ $(openstack loadbalancer member show --format value \
+            --column provisioning_status ${POOL_ID} ${member_id}) = ACTIVE ]]; then
+            break
+        fi
+        echo -n "."
+        sleep 2
+    done
+    echo
+done
 
 floating_ip=$(openstack floating ip create --format value --column floating_ip_address ext_net)
 lb_vip_port_id=$(openstack loadbalancer show --format value --column vip_port_id ${LB_ID})
-openstack floating ip set --port $lb_vip_port_id $floating_ip
+
+openstack floating ip set --port ${lb_vip_port_id} ${floating_ip}
+
+echo "The load balancer is at floating IP ${floating_ip}"
 
 if [[ ${hm_protocol} != HTTP ]]; then
     exit
@@ -180,44 +214,50 @@ fi
 
 L7_POLICY1_ID=$(openstack loadbalancer l7policy create --action REDIRECT_TO_POOL \
     --redirect-pool ${POOL_ID} --name ${lb}-l7policy1 --format value --column id ${LISTENER_ID})
+echo -n "waiting for ${lb}-l7policy1"
 while true; do
     if [[ $(openstack loadbalancer l7policy show ${L7_POLICY1_ID} --format value --column provisioning_status) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for ${lb}-l7policy1"
+    echo -n "."
+    sleep 2
 done
-
-openstack loadbalancer l7policy show ${L7_POLICY1_ID}
+echo
 
 L7_RULE1_ID=$(openstack loadbalancer l7rule create --compare-type STARTS_WITH --type PATH \
     --value /js --format value --column id ${L7_POLICY1_ID})
+echo -n "waiting for ${L7_RULE1_ID}"
 while true; do
     if [[ $(openstack loadbalancer l7rule show --format value --column provisioning_status ${L7_POLICY1_ID} ${L7_RULE1_ID}) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for ${L7_RULE1_ID}"
+    echo -n "."
+    sleep 2
 done
-
-openstack loadbalancer l7rule show ${L7_POLICY1_ID} ${L7_RULE1_ID}
+echo
 
 L7_POLICY2_ID=$(openstack loadbalancer l7policy create --action REDIRECT_TO_POOL \
     --redirect-pool ${lb}-pool --name ${lb}-l7policy2 --format value --column id ${lb}-listener)
+echo -n "waiting for ${lb}-l7policy2"
 while true; do
     if [[ $(openstack loadbalancer l7policy show ${L7_POLICY2_ID} --format value --column provisioning_status) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for ${lb}-l7policy2"
+    echo -n "."
+    sleep 2
 done
-
-openstack loadbalancer l7policy show ${L7_POLICY2_ID}
+echo
 
 L7_RULE2_ID=$(openstack loadbalancer l7rule create --compare-type STARTS_WITH --type PATH \
     --value /images --format value --column id ${L7_POLICY2_ID})
+echo -n "waiting for ${L7_RULE2_ID}"
 while true; do
     if [[ $(openstack loadbalancer l7rule show --format value --column provisioning_status ${L7_POLICY2_ID} ${L7_RULE2_ID}) == ACTIVE ]]; then
         break
     fi
-    echo "waiting for ${L7_RULE2_ID}"
+    echo -n "."
+    sleep 2
 done
+echo
 
-openstack loadbalancer l7rule show ${L7_POLICY2_ID} ${L7_RULE2_ID}
+echo "Load balancer is active"


### PR DESCRIPTION
This change adds the `--subnet-id` command line option to the member create function of Octavia in case the VIP and the member networks are not connected via a router.

The change also cleans up the script a bit.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>