### PR TITLE
Move vault unseal before ./configure

### DIFF
--- a/doc/openstack/tutorial.md
+++ b/doc/openstack/tutorial.md
@@ -61,10 +61,10 @@ Deploy of bundle completed.
 Post-Deployment Info/Actions:
 
 [common]
+  - run ./tools/vault-unseal-and-authorise.sh
   - run ./configure to initialise your deployment
   - source novarc
   - add rules to default security group: ./tools/sec_groups.sh
-  - run ./tools/vault-unseal-and-authorise.sh
 ```
 
 We'll come back to the post deploy steps, but for now,


### PR DESCRIPTION
The tutorial doc, which prints a message after
generate-bundle.sh is run, has ./configure as the
first step. But if you do that there is a complaint
that ./tools/vault-unseal-and-authorise.sh has not
been run yet. A similar message is printed if you
source novarc.

Move it to before ./configure since it must be
run first.