### PR TITLE
Set image properties less aggressively

### DIFF
--- a/openstack/profiles/default
+++ b/openstack/profiles/default
@@ -82,9 +82,8 @@ set_img_properties ()
                        [product_name]="com.ubuntu.cloud:server:${img_version}:amd64"
     )
     for p in ${!props[@]}; do 
-      openstack image set --property $p=${props[$p]} $img_name &
+      openstack image set --property $p=${props[$p]} $img_name
     done
-    wait
 }
 
 # Download images if not already present
@@ -93,6 +92,7 @@ upload_image cloudimages focal focal-server-cloudimg-amd64.img &
 upload_image cloudimages jammy jammy-server-cloudimg-amd64.img &
 upload_image cirros cirros-0.4.0 0.4.0/cirros-0.4.0-x86_64-disk.img &
 wait
+
 # Set properties needed by octavia-disk-image-retrofit (See LP: #1842430)
 set_img_properties focal 20.04 focal-server-cloudimg-amd64.img &
 set_img_properties jammy 22.04 jammy-server-cloudimg-amd64.img &

--- a/openstack/tools/configure_octavia.sh
+++ b/openstack/tools/configure_octavia.sh
@@ -41,7 +41,7 @@ juju config octavia \
     lb-mgmt-controller-cacert="$(base64 $dout/controller_ca.pem)" \
     lb-mgmt-controller-cert="$(base64 $dout/controller_cert_bundle.pem)"
 
-juju $JUJU_RUN_CMD octavia/leader configure-resources
+juju $JUJU_RUN_CMD octavia/leader configure-resources --wait 10m
 
 # Add load-balancer_admin role for admin user
 source $(readlink --canonicalize $(dirname $0))/../novarc

--- a/openstack/tools/upload_octavia_amphora_image.sh
+++ b/openstack/tools/upload_octavia_amphora_image.sh
@@ -1,2 +1,3 @@
 #!/bin/bash -eu
-juju run octavia-diskimage-retrofit/0 retrofit-image
+
+juju run octavia-diskimage-retrofit/0 retrofit-image --wait 10m


### PR DESCRIPTION
The current implementation parallelizes the setting of image properties across the images and the properties. This can lead to some of the properties getting "lost" and not getting set. Missing image properties will break the octavia-diskimage-retrofit charm when one of those images is used as the base for the amphora image.

The `juju run` action has a `--wait` parameter which defaults to `0s` which really means 1 minute. On PS6 this timeout is too aggressive and the configure and retrofit actions time out.