### PR TITLE
Also remove volume that have different names

### DIFF
--- a/tools/cleanup-cinder-attachments.sh
+++ b/tools/cleanup-cinder-attachments.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -u
-for vol in $(openstack volume list| grep juju| grep in-use| awk '{print $2}'); do
+
+for vol in $(openstack volume list --status in-use | awk '{print $2}'); do
     echo "Finding attachments for in-use volume $vol"
     for server in $(openstack volume attachment list  --os-volume-api-version 3.27 --volume-id $vol -c 'Server ID' -f value); do
         openstack server show $server && continue


### PR DESCRIPTION
The 'in-use' volumes, attached to non-existent servers, do not
necessarily have `juju` in their name. This change removes this
restriction.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
