### PR TITLE
Use default 3 computes for hyperconveregd

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -49,6 +49,8 @@ else
 fi
 
 if is_hyperconverged; then
+    # Need at least 3 physical machines so use 3 computes.
+    MOD_PARAMS[__NUM_COMPUTE_UNITS__]=3
     MOD_PARAMS[__GLOBAL_MTU__]=1500
     MOD_PARAMS[__PATH_MTU__]=1500
 fi


### PR DESCRIPTION
Hyperconvereged mode needs at least 3 phyiscal machines to deploy so that applications with min 3 units have somewhere to go.

Resolves: #293