### PR TITLE
Adding the tokens relation

### DIFF
--- a/kubernetes/kubernetes.yaml.template
+++ b/kubernetes/kubernetes.yaml.template
@@ -17,3 +17,4 @@ applications:
     num_units: __NUM_K8S_WORKER_UNITS__
 relations:
   - [ 'kubernetes-control-plane:kube-control', 'kubernetes-worker:kube-control' ]
+  - [ 'kubernetes-control-plane:tokens', 'kubernetes-worker:tokens' ]


### PR DESCRIPTION
Tokens relation is needed so that the kubernetes worker can query metrics information from the kubelet