### PR TITLE
sometimes multiple passwords are generated

### DIFF
--- a/openstack/tools/create_ipv4_octavia.sh
+++ b/openstack/tools/create_ipv4_octavia.sh
@@ -21,7 +21,7 @@ OS_PROJECT_DOMAIN_NAME=service_domain
 OS_USERNAME=octavia
 OS_PROJECT_NAME=services
 OS_USER_DOMAIN_NAME=service_domain
-OS_PASSWORD=$(juju exec --unit octavia/0 "grep -v "auth" /etc/octavia/octavia.conf | grep password" | awk '{print $3}')
+OS_PASSWORD=$(juju exec --unit octavia/0 "grep -v "auth" /etc/octavia/octavia.conf | grep password" | awk '{print $3}' |head -n1)
 EOF
 source /tmp/novarc.services
 


### PR DESCRIPTION
sometimes multiple passwords are generated, eg:

$ juju exec --unit octavia/0 "grep -v "auth" /etc/octavia/octavia.conf | grep password" | awk '{print $3}'
PHVwfkxYmFp2PfZgyzFtLS5ZSdTH3SGcJXYGXJ5LK9ZyKTP5TSRTS46MshkS6jXZ
PHVwfkxYmFp2PfZgyzFtLS5ZSdTH3SGcJXYGXJ5LK9ZyKTP5TSRTS46MshkS6jXZ
PHVwfkxYmFp2PfZgyzFtLS5ZSdTH3SGcJXYGXJ5LK9ZyKTP5TSRTS46MshkS6jXZ

so we will see:

$ ./tools/create_ipv4_octavia.sh
+ true
++ juju status keystone --format json
++ jq -r '.applications.keystone.units."keystone/0"."workload-status".current'
+ [[ active = active ]]
+ break
+ echo INFO: create temp novarc.services and extract octavia password
INFO: create temp novarc.services and extract octavia password
+ touch /tmp/novarc.services
+ cat
++ juju exec --unit octavia/0 'grep -v auth /etc/octavia/octavia.conf | grep password'
++ awk '{print $3}'
+ source /tmp/novarc.services
++ OS_PROJECT_DOMAIN_NAME=service_domain
++ OS_USERNAME=octavia
++ OS_PROJECT_NAME=services
++ OS_USER_DOMAIN_NAME=service_domain
++ OS_PASSWORD=PHVwfkxYmFp2PfZgyzFtLS5ZSdTH3SGcJXYGXJ5LK9ZyKTP5TSRTS46MshkS6jXZ
++ PHVwfkxYmFp2PfZgyzFtLS5ZSdTH3SGcJXYGXJ5LK9ZyKTP5TSRTS46MshkS6jXZ
/tmp/novarc.services: line 6: PHVwfkxYmFp2PfZgyzFtLS5ZSdTH3SGcJXYGXJ5LK9ZyKTP5TSRTS46MshkS6jXZ: command not found