### PR TITLE
Set ovn prefer-chassis-as-gw=true

### DIFF
--- a/overlays/openstack/neutron-ovn.yaml
+++ b/overlays/openstack/neutron-ovn.yaml
@@ -24,6 +24,7 @@ applications:
       debug: *debug
       ovn-bridge-mappings: physnet1:br-data
       bridge-interface-mappings: __OVN_DATA_PORT__
+      prefer-chassis-as-gw: true
 relations:
   - [ neutron-api-plugin-ovn:neutron-plugin, neutron-api:neutron-plugin-api-subordinate ]
   - [ neutron-api-plugin-ovn:ovsdb-cms, ovn-central:ovsdb-cms ]


### PR DESCRIPTION
Before caracal all false meant every node was
a gateway but caracal changed this and results
is no gateways until this is set to true.

See LP 2019217 for more info.