### PR TITLE
Change juju-lnav to bail on failed ssh

### DIFF
--- a/tools/juju-lnav
+++ b/tools/juju-lnav
@@ -6,27 +6,6 @@ declare -A MACHINES=()
 declare -A CONTAINERS=()
 declare -A UNITS=()
 
-install_ssh_key() {
-    local unit
-    for unit in $@; do
-        echo "installing ssh key for ${unit}"
-        if [[ -f ~/testkey.pub ]]; then
-            cat ~/testkey.pub \
-                | timeout 10 juju ssh ${unit} \
-                -- sudo tee --append /root/.ssh/authorized_keys
-        else
-            echo "missing key: ~/testkey.pub"
-        fi
-        if [[ -f ~/.ssh/id_rsa.pub ]]; then
-            cat ~/.ssh/id_rsa.pub \
-                | timeout 10 juju ssh ${unit} \
-                -- sudo tee --append /root/.ssh/authorized_keys
-        else
-            echo "missing key: ~/.ssh/id_rsa.pub"
-        fi
-    done
-}
-
 get_application_units() {
     local application=$1
     local -a units=()
@@ -63,11 +42,34 @@ expand_unit() {
         done
         return
     fi
-    echo "checking ssh key for ${ip_address}"
-    if ! timeout 5 ssh "root@${ip_address}" < /dev//null > /dev/null 2>&1; then
-        install_ssh_key "${ip_address}"
-    fi
+    check_ssh_key "$unit" "$ip_address"
     lnav_arguments=( "${lnav_arguments[@]}" "root@${ip_address}:${files}" )
+}
+
+check_ssh_key() {
+    local unit="$1"
+    local ip_address="$2"
+    echo "checking ssh key for ${ip_address}"
+    if ! ssh \
+        -o ConnectTimeout=5 -o BatchMode=yes \
+        -o StrictHostKeyChecking=accept-new \
+        "root@${ip_address}" true > /dev/null 2>&1; then
+      cat << END
+Unable to ssh into root@${ip_address}.
+Please check that:
+  1. Your public key is in the authorized_hosts file of the root user on ${ip_address}
+     You can accomplish this via e.g.:
+         cat ~/.ssh/your_ssh_key.pub \\
+           | timeout 10 juju ssh ${unit} \\
+             -- sudo tee --append /root/.ssh/authorized_keys
+  2. A different key is not set for this host in ~/.ssh/config,
+     e.g.
+
+       HostName ${ip_address}
+       IdentityFile ~/non_existent_key
+END
+      exit 1
+    fi
 }
 
 get_machine_IPs() {

--- a/tools/juju-lnav
+++ b/tools/juju-lnav
@@ -57,18 +57,18 @@ check_ssh_key() {
       cat << END
 Unable to ssh into root@${ip_address}.
 Please check that:
-  1. Your public key is in the authorized_hosts file of the root user on ${ip_address}
-     You can accomplish this via e.g.:
-         cat ~/.ssh/your_ssh_key.pub \\
-           | timeout 10 juju ssh ${unit} \\
-             -- sudo tee --append /root/.ssh/authorized_keys
-  2. A different key is not set for this host in ~/.ssh/config,
-     e.g.
+1.  Your public key is in the authorized_hosts file of the root user on ${ip_address}
+    You can accomplish this via e.g.:
+        cat ~/.ssh/your_ssh_key.pub \\
+            | timeout 10 juju ssh ${unit} \\
+            -- sudo tee --append /root/.ssh/authorized_keys
+2.  A different key is not set for this host in ~/.ssh/config,
+    e.g.
 
-       HostName ${ip_address}
-       IdentityFile ~/non_existent_key
+    HostName ${ip_address}
+    IdentityFile ~/non_existent_key
 END
-      exit 1
+        exit 1
     fi
 }
 

--- a/tools/juju-lnav
+++ b/tools/juju-lnav
@@ -65,6 +65,9 @@ check_ssh_key() {
 
     echo "Unable to ssh into root@${ip_address}." 1>&2
 
+    # Guess a pub key using ssh -G if not supplied
+    : "${PUB_KEY:=$(ssh -G "root@${ip_address}" |awk '/identityfile/ { print $2; exit }').pub}"
+
     if [[ -n "$PUB_KEY" ]]; then
         copy_pub_key "$unit" "$ip_address"
     else
@@ -94,8 +97,7 @@ copy_pub_key() {
         exit 1
     fi
 
-    cat "${PUB_KEY}" \
-        | timeout 10 juju ssh -q "$unit" \
+    timeout 10 juju ssh -q "$unit" < "$PUB_KEY"\
         -- sudo tee --append /root/.ssh/authorized_keys >/dev/null
 
 
@@ -189,7 +191,8 @@ UNIT        is the name of the unit
 LOGFILES    is a regular shell GLOB
 
 --pub-key PATH      Key to copy to supplied UNIT's authorized_keys file
-                    if ssh authentication fails.
+                    if ssh authentication fails. Default: the first key
+                    returned by 'ssh -G' for the given host.
 EOF
             exit 0
             ;;

--- a/tools/juju-lnav
+++ b/tools/juju-lnav
@@ -2,6 +2,7 @@
 
 set -e -u
 
+declare PUB_KEY=
 declare -A MACHINES=()
 declare -A CONTAINERS=()
 declare -A UNITS=()
@@ -46,23 +47,62 @@ expand_unit() {
     lnav_arguments=( "${lnav_arguments[@]}" "root@${ip_address}:${files}" )
 }
 
+can_ssh_connect() {
+    local ip_address="$1"
+    ssh \
+        -o ConnectTimeout=5 -o BatchMode=yes \
+        -o StrictHostKeyChecking=no \
+        "root@${ip_address}" true > /dev/null 2>&1
+}
+
 check_ssh_key() {
     local unit="$1"
     local ip_address="$2"
     echo "checking ssh key for ${ip_address}"
-    if ! ssh \
-        -o ConnectTimeout=5 -o BatchMode=yes \
-        -o StrictHostKeyChecking=accept-new \
-        "root@${ip_address}" true > /dev/null 2>&1; then
-      cat << END
-Unable to ssh into root@${ip_address}.
+    if can_ssh_connect "$ip_address"; then
+        return
+    fi
+
+    echo "Unable to ssh into root@${ip_address}." 1>&2
+
+    if [[ -n "$PUB_KEY" ]]; then
+        copy_pub_key "$unit" "$ip_address"
+    else
+        cat << END
 Please check that:
 1.  Your public key is in the authorized_hosts file of the root user on ${ip_address}
-    You can accomplish this via e.g.:
-        cat ~/.ssh/your_ssh_key.pub \\
-            | timeout 10 juju ssh ${unit} \\
-            -- sudo tee --append /root/.ssh/authorized_keys
+    You can accomplish this by rerunning this script with the --pub-key flag:
+    ./juju-lnav --pub-key ~/.ssh/id_rsa.pub UNIT:LOG
+
 2.  A different key is not set for this host in ~/.ssh/config,
+    e.g.
+
+    HostName ${ip_address}
+    IdentityFile ~/non_existent_key
+END
+        exit 1
+    fi
+}
+
+copy_pub_key() {
+    local unit="$1"
+    local ip_address="$2"
+    echo "copying ${PUB_KEY} to ${unit}'s authorized_keys"
+
+    if ! [[ -f "${PUB_KEY}" ]]; then
+        echo "${PUB_KEY} does not exist." 1>&2
+        exit 1
+    fi
+
+    cat "${PUB_KEY}" \
+        | timeout 10 juju ssh -q "$unit" \
+        -- sudo tee --append /root/.ssh/authorized_keys >/dev/null
+
+
+    if ! can_ssh_connect "$ip_address"; then
+        echo "Still unable to connect to ${ip_address}"
+        cat << END
+Please check that a different key is not set for this host in ~/.ssh/config,
     e.g.
 
     HostName ${ip_address}
@@ -147,8 +187,15 @@ Options:
 
 UNIT        is the name of the unit
 LOGFILES    is a regular shell GLOB
+
+--pub-key PATH      Key to copy to supplied UNIT's authorized_keys file
+                    if ssh authentication fails.
 EOF
             exit 0
+            ;;
+        --pub-key)
+            PUB_KEY="$2"
+            shift
             ;;
         *)
             if (( juju_info_loaded == 0 )); then

--- a/tools/juju-lnav
+++ b/tools/juju-lnav
@@ -68,6 +68,9 @@ check_ssh_key() {
     # Guess a pub key using ssh -G if not supplied
     : "${PUB_KEY:=$(ssh -G "root@${ip_address}" |awk '/identityfile/ { print $2; exit }').pub}"
 
+    # 'Good Enough' tilde expansion
+    PUB_KEY="${PUB_KEY/#\~/$HOME}"
+
     if [[ -n "$PUB_KEY" ]]; then
         copy_pub_key "$unit" "$ip_address"
     else


### PR DESCRIPTION
* Remove install_ssh_key
* Add check_ssh_key and exit if unable to connect

Previously juju-lnav attempted to copy the keys
`~/.ssh/id_rsa.pub` and `~/testkey.pub` to a server when connecting to a machine, if an initial ssh test failed. This could lead to confusing errors if either of the above keys was missing, and wouldn't necessarily fix connectivity issues. Also, lnav doesn't make it especially clear what's going on if it is unable to ssh.

This commit changes the script to bail out if it can't establish and ssh connection with the target machine, and instead prints instructions to the user letting them know they should add an ssh key to the server and try again.