### PR TITLE
Fix redirection when the noclobber is 'on'

### DIFF
--- a/openstack/novarc
+++ b/openstack/novarc
@@ -7,7 +7,7 @@ trap cleanup EXIT KILL
 scriptdir=$(readlink --canonicalize $(dirname ${BASH_SOURCE}))
 
 # cache juju status
-juju status --format=json > $juju_status_json_cache
+juju status --format=json >| $juju_status_json_cache
 
 _OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}'))
 for param in ${_OS_PARAMS[@]}; do


### PR DESCRIPTION
If bash (or zsh) has the noclobber option enabled 'set -o noclobber' the regular redirection '>' will fail. This patch solves the problem for both situations (noclobber 'on' or 'off')