### PR TITLE
Fix channel for watcher

### DIFF
--- a/common/charm_lists
+++ b/common/charm_lists
@@ -41,6 +41,7 @@ pacemaker-remote
 placement
 swift-proxy
 swift-storage
+watcher
 )
 
 declare -a OVN_CHARMS=(


### PR DESCRIPTION
Without this fix, generate-bundle.sh generates the watcher overlay with the incorrect channel: latest/edge. Depending on the OpenStack release the charm should follow the proper track, ie 2024.1 for Caracal.