### PR TITLE
Relate cinder-volume to vault:certificates

### DIFF
--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -721,6 +721,9 @@ do
             assert_min_release ussuri 'cinder-volume'
             MOD_OVERLAYS+=( "openstack/cinder-volume.yaml" )
             MOD_PARAMS[__CINDER_VOLUME_INTERFACE__]='cinder-volume'
+            if has_opt --vault || is_ml2_ovn; then
+                MOD_OVERLAYS+=( "openstack/vault-openstack-certificates-cinder-volume.yaml" )
+            fi
             ;;
         --purestorage-api-token)  #__OPT__type:<str>
             MOD_PARAMS[__PURESTORAGE_API_TOKEN__]=$2

--- a/overlays/openstack/vault-openstack-certificates-cinder-volume.yaml
+++ b/overlays/openstack/vault-openstack-certificates-cinder-volume.yaml
@@ -1,0 +1,2 @@
+relations:
+  - ['cinder-volume:certificates', 'vault:certificates']


### PR DESCRIPTION
When using --cinder-volume, we didn't link it to vault:certificates and
it failed to connect to keystone/nova etc due to an SSL error.

Add the relation when vault is in use.
