### PR TITLE
Fix watcher deployment

### DIFF
--- a/openstack/module_defaults
+++ b/openstack/module_defaults
@@ -52,6 +52,9 @@ MOD_PARAMS[__MAAS_API_KEY__]=
 MOD_PARAMS[__GLOBAL_MTU__]=1500
 MOD_PARAMS[__PATH_MTU__]=
 MOD_PARAMS[__NUM_WATCHER_UNITS__]=1
+MOD_PARAMS[__WATCHER_DATASOURCES__]='gnocchi'
+MOD_PARAMS[__WATCHER_PLANNER__]='weight'
+MOD_PARAMS[__WATCHER_PLANNER_CONFIG__]='{"weights": "change_node_power_state:9,change_nova_service_state:50,migrate:30,nop:70,resize:20,sleep:40,turn_host_to_acpi_s3_state:10,volume_migrate:60","parallelization": "change_node_power_state:2,change_nova_service_state:1,migrate:2,nop:1,resize:2,sleep:1,turn_host_to_acpi_s3_state:2,volume_migrate:2"}'
 MOD_PARAMS[__NUM_MAGNUM_UNITS__]=1
 
 # This is enough for creating one ubuntu vm or multiple cirros vms but some

--- a/openstack/pipeline/02configure
+++ b/openstack/pipeline/02configure
@@ -662,7 +662,7 @@ do
             fi
             if ! has_opt --ssl; then
                 MOD_OVERLAYS+=( "openstack/vault-openstack-certificates.yaml" )
-                for opt in --heat --octavia --barbican --designate --placement --openstack-dashboard --ironic; do
+                for opt in --heat --octavia --barbican --designate --placement --openstack-dashboard --ironic --watcher; do
                     has_opt $opt* && MOD_OVERLAYS+=( "openstack/vault-openstack-certificates-${opt##--}.yaml" )
                 done
             fi

--- a/overlays/openstack/vault-openstack-certificates-watcher.yaml
+++ b/overlays/openstack/vault-openstack-certificates-watcher.yaml
@@ -1,0 +1,2 @@
+relations:
+  - ['watcher:certificates', 'vault:certificates']

--- a/overlays/openstack/watcher.yaml
+++ b/overlays/openstack/watcher.yaml
@@ -10,6 +10,9 @@ applications:
     options:
       debug: *debug
       openstack-origin: *openstack_origin
+      datasources: '__WATCHER_DATASOURCES__'
+      planner: '__WATCHER_PLANNER__'
+      planner-config: '__WATCHER_PLANNER_CONFIG__'
 relations:
   - [ watcher:shared-db, __MYSQL_INTERFACE__ ]
   - [ watcher:identity-service, keystone:identity-service ]

--- a/overlays/unit_placement/watcher.yaml.template
+++ b/overlays/unit_placement/watcher.yaml.template
@@ -1,0 +1,3 @@
+  watcher:
+    to:
+__UNIT_PLACEMENT_LXD__.__UNITS__.__NUM_WATCHER_UNITS__


### PR DESCRIPTION
This patch adds mandatory watcher config settings. Without those, the charm fails to deploy. See https://docs.openstack.org/charm-guide/latest/admin/compute/watcher.html#deployment for details.

This patch also adds a certificates relation to the vault.