### PR TITLE
Change 'Member' role to 'member'

### DIFF
--- a/openstack/profiles/common
+++ b/openstack/profiles/common
@@ -63,7 +63,7 @@ function install_packages {
 }
 
 function create_roles {
-    openstack role show Member || openstack role create Member
+    openstack role show member || openstack role create member
     openstack role show ResellerAdmin || openstack role create ResellerAdmin
 }
 
@@ -80,7 +80,7 @@ function create_tempest_users {
                               --enable \
                               --email demo@dev.null demo
     }
-    openstack role add --user demo --project demo Member || :
+    openstack role add --user demo --project demo member || :
 
     openstack project show alt_demo || {
         openstack project create alt_demo
@@ -91,7 +91,7 @@ function create_tempest_users {
                               --enable \
                               --email alt_demo@dev.null alt_demo
     }
-    openstack role add --user alt_demo --project alt_demo Member || :
+    openstack role add --user alt_demo --project alt_demo member || :
 }
 
 function create_tempest_users_v3 {
@@ -111,7 +111,7 @@ function create_tempest_users_v3 {
     openstack role add --user-domain admin_domain \
                        --user demo \
                        --project-domain admin_domain \
-                       --project demo Member || :
+                       --project demo member || :
 
     openstack project show --domain admin_domain alt_demo || {
         openstack project create --domain admin_domain alt_demo
@@ -128,7 +128,7 @@ function create_tempest_users_v3 {
     openstack role add --user-domain admin_domain \
                        --user alt_demo \
                        --project-domain admin_domain \
-                       --project alt_demo Member || :
+                       --project alt_demo member || :
 }
 
 function create_tempest_flavors {

--- a/openstack/templates/tempest/tempest.conf.oil_example
+++ b/openstack/templates/tempest/tempest.conf.oil_example
@@ -304,7 +304,7 @@ accounts_quotas_available = True
 container_quotas_available = True
 
 # Set operator role for tests that require creating a container
-operator_role = Member
+operator_role = member
 
 #jamespage
 accounts_quotas_available = True
@@ -393,7 +393,7 @@ dashboard_url = http://{{ horizon_host }}/horizon
 login_url = http://{{ horizon_host }}/horizon/auth/login/
 
 [scenario]
-# Cirros from http://download.cirros-cloud.net/0.3.1/cirros-0.3.1-x86_64-uec.tar.gz 
+# Cirros from http://download.cirros-cloud.net/0.3.1/cirros-0.3.1-x86_64-uec.tar.gz
 # Directory containing image files
 img_dir = /var/lib/jenkins/images/
 

--- a/openstack/tools/create_project.sh
+++ b/openstack/tools/create_project.sh
@@ -1,23 +1,23 @@
 #!/bin/bash -eux
-id=`uuidgen`
+id=$(uuidgen)
 project_name=${1:-project-$id}
 domain=${2:-user_domain}
 network=${3:-172.16.0.0/24}
 
 # ensure deps
-dpkg -s ipcalc &>/dev/null|| sudo apt install ipcalc -y
+dpkg -s ipcalc &>/dev/null || sudo apt install ipcalc -y
 
 echo "Creating project $project_name"
 
 openstack domain show $domain 2>/dev/null || openstack domain create $domain
-p_id=`openstack project create --domain $domain --enable $project_name -c id -f value`
-u_id=`openstack user create --project $p_id --password ubuntu --enable --email $project_name@dev.null user-$id --domain $domain -c id -f value`
+p_id=$(openstack project create --domain $domain --enable $project_name -c id -f value)
+u_id=$(openstack user create --project $p_id --password ubuntu --enable --email $project_name@dev.null user-$id --domain $domain -c id -f value)
 
 # general role
-openstack role add --user $u_id --user-domain $domain --project $p_id --project-domain $domain Member
+openstack role add --user $u_id --user-domain $domain --project $p_id --project-domain $domain member
 
 # add roles for octavia if its in use
-if ((`juju status octavia --format=json 2>/dev/null| jq '.machines| length'`)); then
+if (($(juju status octavia --format=json 2>/dev/null | jq '.machines| length'))); then
     openstack role add --user $u_id --user-domain $domain --project $p_id --project-domain $domain load-balancer_observer &
     openstack role add --user $u_id --user-domain $domain --project $p_id --project-domain $domain load-balancer_member &
     wait
@@ -25,7 +25,7 @@ fi
 
 openstack role assignment list --user $u_id
 
-cat << EOF > novarc.$project_name
+cat <<EOF >novarc.$project_name
 export OS_AUTH_URL=$OS_AUTH_URL
 export OS_REGION_NAME=RegionOne
 export OS_PROJECT_NAME=$project_name
@@ -36,14 +36,14 @@ export OS_PASSWORD=ubuntu
 export OS_USERNAME=user-$id
 EOF
 
-net_start=`ipcalc $network| awk '$1=="HostMin:" {print $2}'`
-net_end=`ipcalc $network| awk '$1=="HostMax:" {print $2}'`
+net_start=$(ipcalc $network | awk '$1=="HostMin:" {print $2}')
+net_end=$(ipcalc $network | awk '$1=="HostMax:" {print $2}')
 d=${net_start##*.}
 net_start=${net_start%.*}.$((++d))
 
-n_id="`openstack network create --enable private --project $p_id --project-domain $domain -c id -f value`"
-sn_id="`openstack subnet create --allocation-pool start=$net_start,end=$net_end \
-                        --subnet-range $network --dhcp --ip-version 4 --network $n_id private_subnet --project $p_id --project-domain $domain -c id -f value`"
+n_id="$(openstack network create --enable private --project $p_id --project-domain $domain -c id -f value)"
+sn_id="$(openstack subnet create --allocation-pool start=$net_start,end=$net_end \
+    --subnet-range $network --dhcp --ip-version 4 --network $n_id private_subnet --project $p_id --project-domain $domain -c id -f value)"
 
 openstack router create ${project_name}-router --project $p_id --project-domain $domain
 openstack router add subnet ${project_name}-router $sn_id &


### PR DESCRIPTION
Versions of the openstack client >= 7.3.x
treat role names as case sensitive while
keystone treats them as case insensitive.

This leads to problems like
`openstack role show Member` returning
nothing even if the role `member` exists
but then `openstack create role Member` failing
due to a name collision. Since the `member` role
seems to be created as lowercase by default we
adopt that convention in the config.

Fixes #350
