### PR TITLE
Rename charm artifact inline when rename.sh is missing

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -259,6 +259,16 @@ elif [[ -n $REMOTE_BUILD ]]; then
     rsync -vza $REMOTE_BUILD_DESTINATION:$REMOTE_BUILD_PATH/*.charm .
 fi
 
+# If rename.sh has been removed from the charm repo, rename the built
+# artifact here (same as rename.sh would have done). Only applies when a
+# fresh build was produced locally or via --remote-build.
+if { ! $SKIP_BUILD || [[ -n $REMOTE_BUILD ]]; } && [[ ! -f rename.sh ]] \
+        && compgen -G "${CHARM_NAME}_*.charm" >/dev/null; then
+    echo "rename.sh not found; renaming ${CHARM_NAME}_*.charm -> ${CHARM_NAME}.charm"
+    rm -f "${CHARM_NAME}.charm"
+    mv "${CHARM_NAME}"_*.charm "${CHARM_NAME}.charm"
+fi
+
 # 3. Run functional tests.
 
 # If a func test pr is provided switch to that pr.


### PR DESCRIPTION
Some charm repos no longer ship a rename.sh helper(although it is in master (in progress), I think it's test suite's responsibility), so the build step leaves the artifact named ${charm}_${arch}.charm.
The test phase and bundle references expect the canonical ${charm}.charm. 
Do the rename inline after build (local or --remote-build) when rename.sh is absent, mirroring what rename.sh would have done. 

e.g https://review.opendev.org/c/openstack/charm-heat/+/985457