### PR TITLE
Catch popd stack empty

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -322,7 +322,7 @@ if [[ -n $RERUN_PHASE ]]; then
     juju switch $model
     [[ ${#FUNC_TEST_TARGET[@]}==1 ]] && bundle=${FUNC_TEST_TARGET[0]} || bundle=
     run_test_phase $RERUN_PHASE $model $bundle
-    popd
+    popd &>/dev/null || true
 fi
 
 first=true


### PR DESCRIPTION
Classic charms don't have a src dir so popd stack will be empty. Catch popd stack empty error to allow script to continue