### PR TITLE
Check that user specified arguments if required

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -63,6 +63,8 @@ OPTIONS:
         enough capacity to boot the vms required by the tests.
     --sleep TIME_SECS
         Specify amount of seconds to sleep between functest steps.
+    --debug
+        Run with debug (-x) enabled.
     --help
         This help message.
 EOF
@@ -143,6 +145,10 @@ while (($# > 0)); do
             set -x
             ;;
         --func-test-target)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             FUNC_TEST_TARGET+=( $2 )
             shift
             ;;
@@ -157,11 +163,19 @@ while (($# > 0)); do
             WAIT_ON_DESTROY=false
             ;;
         --remote-build)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             REMOTE_BUILD=$2
             SKIP_BUILD=true
             shift
             ;;
         --rerun)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             RERUN_PHASE=$2
             [[ $2 = deploy ]] || [[ $2 = configure ]] || [[ $2 = test ]] || opt_error $1 $2
             shift
@@ -173,6 +187,10 @@ while (($# > 0)); do
             SKIP_BUILD=true
             ;;
         --sleep)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             SLEEP=$2
             shift
             ;;

--- a/openstack/tools/openstack_regression_tests_runner.sh
+++ b/openstack/tools/openstack_regression_tests_runner.sh
@@ -30,6 +30,8 @@ OPTIONS:
         By default we modify test bundle constraints to ensure that applications
         have the resources they need. For example nova-compute needs to have
         enough capacity to boot the vms required by the tests.
+    --debug
+        Run with debug (-x) enabled.
     --help
         This help message.
 EOF
@@ -47,14 +49,26 @@ while (($# > 0)); do
             set -x
             ;;
         --func-test-target)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             FUNC_TEST_TARGET=$2
             shift
             ;;
         --func-test-pr)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             FUNC_TEST_PR=$2
             shift
             ;;
         --rerun)
+            if [[ $# < 2 ]]; then
+                echo "ERROR: '$1' requires argument"
+                exit 1
+            fi
             RERUN_PHASE=$2
             [[ $2 = configure ]] || [[ $2 = test ]] || opt_error $1 $2
             shift


### PR DESCRIPTION
Some options in the test runner code require arguments, otherwise they throw an exception, for example:

$ ./openstack_regression_tests_runner.sh --func-test-target ./openstack_regression_tests_runner.sh: line 50: $2: unbound variable

If there is not at least one more argument remaining, error out with a message so the user can correct the call.