### PR TITLE
Fix --help and --list-overlays extra delay

### DIFF
--- a/common/helpers
+++ b/common/helpers
@@ -14,9 +14,6 @@ declare -A MASTER_OPTS=(
     [CHARM_STORE]=ch:
 )
 DEFAULT_SERIES=jammy
-JUJU_VERSION="`juju show-controller| sed -r 's/.+controller-model-version:\s+(.+)/\1/g;t;d' 2>/dev/null`" || true
-[ -n "$JUJU_VERSION" ] || JUJU_VERSION="`juju --version 2>/dev/null| sed -r 's/^([[:digit:]\.]+).*/\1/g'`"
-JUJU_DEPLOY_OPTS=""
 
 . $MOD_DIR/common/openstack_release_info
 . $MOD_DIR/common/ceph_release_info
@@ -275,6 +272,11 @@ filter_master_opts ()
 }
 # Update $@ with filtered set of opts
 filter_master_opts ${CACHED_STDIN[@]}
+
+JUJU_VERSION="`juju show-controller| sed -r 's/.+controller-model-version:\s+(.+)/\1/g;t;d' 2>/dev/null`" || true
+[ -n "$JUJU_VERSION" ] || JUJU_VERSION="`juju --version 2>/dev/null| sed -r 's/^([[:digit:]\.]+).*/\1/g'`"
+JUJU_DEPLOY_OPTS=""
+
 set -- ${FILTERED[@]}
 
 has_excl_passthrough_opt ()


### PR DESCRIPTION
These switches (`--help`, `--list-overlays`) cause the `generate-bundle.sh` to exit early. 
If you just want to check help or list the supported overlays, and the juju controller is not reachable, before this patch, the command would take ages, waiting for the juju controller's response timeout.
I moved that part further down the execution flow once we know we don't exit early.