### PR TITLE
Add stsstack-bug-repro skill for Claude Code and Codex CLI

### DIFF
--- a/.agents/skills/stsstack-bug-repro/SKILL.md
+++ b/.agents/skills/stsstack-bug-repro/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: stsstack-bug-repro
+description: Reproduce a Charmed OpenStack bug locally from a public Launchpad bug. Classifies as a charm bug (clone the charm from opendev, run `charmed_openstack_functest_runner.sh`) or a service-level bug (deploy via stsstack-bundles, trigger manually), executes mutating steps only with explicit per-step confirmation, then verifies and reports cross-branch fix status with backport guidance. Use whenever the user mentions an LP bug number/URL, asks to reproduce an OpenStack symptom locally, or wants a stsstack-bundles setup for a specific bug — even if they don't say "reproduce". OpenStack only; rejects non-OpenStack components and private LP bugs.
+---
+
+# stsstack-bug-repro
+
+Translate a Charmed OpenStack bug into a runnable reproduction, then — with confirmation — execute and verify it.
+
+## When to use
+
+The user gives you a Charmed OpenStack bug to reproduce. Typical inputs:
+
+- Public Launchpad bug number/URL (e.g., `LP#2089616`, `https://bugs.launchpad.net/...`)
+- Symptom description in an OpenStack component ("HA Keystone fails on Caracal", "Octavia LB stuck in PENDING_CREATE on OVN", ...)
+- "Set up an env where I can hit X" for an OpenStack scenario
+
+## When NOT to use — reject upfront
+
+Stop and tell the user the skill cannot proceed:
+
+- **Private LP bug** — JSON has `"private": true`, page says "This bug is private", or WebFetch returns 401/404. Ask the user to make it public or paste the relevant text. Don't try to bypass.
+- **Not an OpenStack component** — pure Ceph (`ceph-mon`, `ceph-osd`, `rbd`, `cephfs` standalone), pure Kubernetes / Charmed K8s, ops-framework charms (COS, MicroK8s, identity-platform, `*-k8s`), Kafka, JAAS, Landscape, OSM, Swift-standalone. See `references/charm-types.md` for why ops charms are out of scope.
+- **Bug in stsstack-bundles itself** (template/script) — treat as a normal code task.
+- **Normal deployment request** — point at `openstack/generate-bundle.sh --help` and `openstack/AGENTS.md`.
+- **RFE / blueprint / architectural change** — title starts with `[RFE]`, `[Spec]`, `[Feature]`, body uses "request"/"support"/"deprecate", or Launchpad importance is `Wishlist`. This skill reproduces existing defects; RFEs have no trigger to reproduce ("missing feature" is the symptom). Tell the user to use a feature-design workflow instead.
+
+OpenStack bugs that *involve* Ceph or K8s as a backend (Cinder-Ceph, Manila-CephFS, Magnum-K8s) are in scope — they go in via overlays, not a separate stack.
+
+## Read first
+
+- `AGENTS.md` (repo root) and `openstack/AGENTS.md` — source of truth for stack layout, options, overlays, conventions.
+- `common/openstack_release_info` — release/series mapping. Details in `references/release-mapping.md`.
+- `https://releases.openstack.org/` — WebFetch every time to know the current dev cycle and per-series support status (Maintained/EM/EOL). Training data goes stale within a 6-month cycle.
+
+## Procedure
+
+### 1. Fetch the Launchpad bug
+
+WebFetch both:
+- Human page: `https://bugs.launchpad.net/+bug/<num>`
+- JSON: `https://api.launchpad.net/devel/bugs/<num>`
+
+If the response indicates private/inaccessible → reject (see above). If the user pasted the bug text directly, skip the fetch and extract from that text.
+
+Extract: affected project / source package, OpenStack release / charm channel, Ubuntu series, symptom and trigger. Don't echo private comments or credentials — reference them as "LP comment #N" without quoting.
+
+### 2. Classify
+
+Choose the **charm path** when any holds:
+
+- LP project is `charm-<name>` (opendev `openstack/charm-*`, reactive framework).
+- Bug references charm config, charm channels/tracks, or a failing CI test target (osci.yaml, zaza, charm-CI tempest selector).
+- Reporter pasted `juju config` / `juju status` as the trigger artefact.
+
+Otherwise use the **service-level path** — the bug is in the OpenStack service code itself; deployment is incidental.
+
+If unclear, ask once: "Is this a charm bug (CI-equivalent repro via the charm repo) or a service-level bug (manual repro on a stsstack-bundles cloud)?"
+
+### 3. Extract dimensions
+
+Identify and mark unknowns explicitly (don't invent):
+
+- OpenStack release + Ubuntu series
+- Charm channel/track (also drives charm branch)
+- HA topology (single vs N units + hacluster)
+- Optional components (Vault, LDAP, Octavia, Heat, Designate, Manila, Magnum, Barbican, Ceph, K8s integration)
+- Network plugin (ML2-OVS vs ML2-OVN)
+- Provider/substrate (MAAS, LXD, OS-on-OS, public cloud)
+- Profile (`default` / `stsstack` / `serverstack` / `prodstack5|6|7` / `metal`)
+- Trigger action — for charm path usually a `--func-test-target`; for service path a CLI/API call or test
+
+**If release/series is not specified**, choose the default based on bug age:
+
+- **Recent bug** (created in the last ~2 years) → current dev release (codename from `https://releases.openstack.org/`).
+- **Old bug** (>2 years old, no release stated) → a release **contemporary with the bug's creation date**, not current dev. A 2019 bug almost certainly targeted Rocky/Stein/Train, and reproducing it on Hibiscus is misleading (the code path may not exist anymore). Cross-check with `git log <suspected-area> --before <bug-creation-date>`.
+
+If the chosen codename isn't in `common/openstack_release_info`, see `references/release-mapping.md` for the fallback rule.
+
+**If the bug lists a release range** (e.g., "ussuri through xena", "yoga / 2023.1 / 2023.2", "rocky and later"), ask the user which to reproduce on, or default to the **most recent affected release that is still active** (per releases.openstack.org Maintained status + charm activity heuristic). State the choice in the recipe so the user can override.
+
+Also from releases.openstack.org, capture each series' support status (Maintained / EM / Unmaintained / EOL) — step 6 needs it.
+
+### 4. Execute the path
+
+- **Charm path** → follow `references/charm-path.md` (locate the fix across branches, checkout, run the functest runner).
+- **Service path** → follow `references/service-path.md` (map dimensions to flags/overlays, produce a recipe, generate/deploy/configure/trigger).
+
+### 5. Verify reproduction
+
+- Charm path: read the runner's exit status and the zaza/tempest output.
+- Service path: run the observation commands from the recipe.
+
+Call out **reproduced**, **did not reproduce**, or **inconclusive**. On reproduction, report the matching evidence (command output, log line, status field) — don't paste secrets. On failure-to-reproduce, collect the logs listed in the recipe and suggest the next dimension to vary (flip OVS↔OVN, switch profile, try a different channel).
+
+### 6. Cross-branch fix status and backport guidance
+
+After step 5, produce a branch-by-branch fix-status report. Service-level uses the upstream OpenStack Maintained/EM/EOL labels; charms use an activity heuristic instead (Canonical keeps older charm branches alive past upstream EOL). Details in `references/cross-branch.md`, including:
+
+- locating fix commits (and the Gerrit Change-Id fallback when `git log --grep` is empty),
+- the status table format,
+- service-vs-charm classification rules,
+- recommended next action per fix-presence pattern,
+- a patch proposal sketch when no fix exists anywhere (step 5 evidence → file:function → smallest diff → test).
+
+### 7. Confirmation gates for mutating commands
+
+Read-only inspection runs without asking: file reads, `./generate-bundle.sh --help` / `--list-overlays`, `git clone` / `git checkout` / `git log`, `juju status`, log fetches, WebFetch.
+
+Each of these prompts for confirmation, one at a time. Approval for one step does NOT carry to the next. If the user declines, output the command for manual execution.
+
+- **Charm path**: `charmed_openstack_functest_runner.sh` (deploys a model).
+- **Service path**: `generate-bundle.sh`, deploy, `configure`, trigger.
+
+## Hard rules
+
+- **OpenStack only.** Non-OpenStack or private LP bug → reject and stop. (Why: scope; private bugs may contain customer data.)
+- **Confirm before each mutating step.** Each consumes real resources (Juju model, VMs/units, time). Re-confirm per step.
+- **Don't invent flag or overlay names.** Use only what `--help` / `--list-overlays` show. If missing, stop and say so.
+- **Cite evidence** for non-obvious mappings (file:line).
+- **No secrets** echoed from LP. Reference as "found in LP comment #N" without quoting.
+
+## Examples
+
+**Charm bug, fix already on all branches**
+User: "Reproduce LP#1877168"
+→ Fetch → charm-nova-compute, OpenStack Train → clone charm-nova-compute → `git log --grep "1877168"` finds `d6a1c4f` "Fix cpu_dedicated_set generation in nova.conf" → `git branch -r --contains d6a1c4f` shows all stable branches → report "already fixed everywhere; reproduce only if user wants pre-fix validation" → wait for user.
+
+**Service bug, release not specified**
+User: "Set up an env for LP#2051907"
+→ Fetch → upstream nova, live-migrate policy issue, no release stated → WebFetch releases.openstack.org → current dev = Hibiscus (2026.2) → grep `common/openstack_release_info` → Hibiscus absent → fall back to Flamingo (2025.2, latest supported), note the deviation → produce recipe with `--release flamingo --series questing --num-compute 2`, trigger via `openstack server live-migrate ...` → ask per-step confirmation.
+
+**Rejection**
+User: "Reproduce LP#1979330"
+→ Fetch → charm-ceph-mon, no OpenStack involvement → reject: "This skill is OpenStack-only. For pure Ceph charm bugs, use the stsstack-bundles `ceph/` stack directly — see `ceph/AGENTS.md` if present."

--- a/.agents/skills/stsstack-bug-repro/references/charm-path.md
+++ b/.agents/skills/stsstack-bug-repro/references/charm-path.md
@@ -1,0 +1,64 @@
+# Charm path (step 4A)
+
+Each charm has its own test definitions (bundles, zaza configs, tempest selectors) under `tests/` in its repo. The OpenStack CI (OSCI) entry point lives at `osci.yaml`. stsstack-bundles ships `openstack/tools/charmed_openstack_functest_runner.sh`, which mimics OSCI from inside the charm checkout.
+
+## 4A.0 — Locate the fix (if any) across branches first
+
+Before deciding which branch to reproduce on, find out where the fix lives. This drives: (a) which branches still exhibit the bug, (b) which branches need a backport.
+
+```
+# Clone *full*, not shallow — shallow clones miss older fix commits.
+git clone https://opendev.org/openstack/charm-<name>.git
+cd charm-<name>
+git log --all --oneline \
+        --grep "Closes-Bug: #<num>" \
+        --grep "LP#<num>" \
+        --grep "lp:#<num>" -i
+# List branches containing the fix:
+git branch -r --contains <fix-sha>
+```
+
+If you cloned shallowly (`--depth N`) and the search returned nothing, run `git fetch --unshallow` and retry before declaring "no fix" — the fix may simply be deeper than your fetch window.
+
+If `git log --grep` finds nothing even after unshallow, fall back to Gerrit (see `cross-branch.md` 8.1).
+
+**Pick the reproduction branch** as the one matching the bug's release that does NOT contain the fix. If every branch already contains the fix, the bug should be closed/verified — confirm with the user before continuing. They may want pre-fix repro for regression-test validation: checkout the parent of the fix commit (`git checkout <fix-sha>^`).
+
+## 4A.1 — Checkout the matching branch
+
+Reuse the clone from 4A.0. Branch ↔ release map varies per charm — three styles in the wild:
+
+- `master` → current dev
+- `stable/<codename>` (e.g., `stable/caracal`, `stable/yoga`) — older OpenStack-service charms
+- `stable/<yyyy.N>` (e.g., `stable/2024.1`) — newer OpenStack-service charms
+- `stable/<ubuntu-series>` (e.g., `stable/jammy`, `stable/focal`) — **data/infra charms** that don't track OpenStack release cycles directly: `charm-mysql-innodb-cluster`, `charm-percona-cluster`, `charm-rabbitmq-server`, and similar. Map the bug's release to its contemporaneous Ubuntu LTS via `common/openstack_release_info` (`lts[]`) to pick the right branch.
+
+Pick the branch matching the bug's release. `git branch -r | grep stable` shows what's actually there for this charm. If the bug's exact release has no branch, see `charm-types.md` for activity-based fallback rules.
+
+```
+git checkout stable/<release-or-yyyy.N>
+```
+
+If the bug pre-dates a fix that's already on this branch, checkout the parent of the fix commit (`<sha>^`) rather than reverting — don't silently rewrite history.
+
+## 4A.2 — Run the functest runner
+
+From inside the charm clone, invoke the runner that lives in stsstack-bundles:
+
+```
+<stsstack-bundles>/openstack/tools/charmed_openstack_functest_runner.sh \
+    --func-test-target <target-from-osci.yaml> \
+    [--manual-functests]              # split deploy/configure/test phases
+    [--skip-build]                    # if you already built the charm
+    [--rerun deploy|configure|test]   # resume after a phase
+```
+
+Read the charm's `osci.yaml` (or `src/tests/tests.yaml`) to find the right `--func-test-target`. The bug's trigger should map to one of those targets. If the bug refers to a specific tempest test, it usually corresponds to a charm test target whose bundle wires up tempest with the right selectors.
+
+The runner handles the full cycle (build → deploy → configure → run tests). Don't separately invoke `generate-bundle.sh` for the charm path — the runner uses bundles from the charm's `tests/` dir.
+
+`--manual-functests` is useful for intermittent bugs: deploy once, then re-run only the test phase under different conditions.
+
+## 4A.3 — Verify
+
+See `SKILL.md` step 5.

--- a/.agents/skills/stsstack-bug-repro/references/charm-types.md
+++ b/.agents/skills/stsstack-bug-repro/references/charm-types.md
@@ -1,0 +1,43 @@
+# Charm types — scope rules
+
+Charms come in three frameworks. This skill targets only **reactive**.
+
+## reactive
+
+- `charms.reactive` + `charm-helpers` source layer + interface layers.
+- Hosted on opendev: `https://opendev.org/openstack/charm-<name>`.
+- Used by VM-based OpenStack deployments (what stsstack-bundles deploys).
+- **In scope.**
+
+## ops (operator framework)
+
+- `ops` Python library, single-class operator pattern.
+- Mostly K8s-related charms: COS (Grafana/Prometheus/Loki), MicroK8s, identity-platform, `*-k8s` charms, Kubeflow.
+- Hosted on GitHub (`canonical/`, `openstack-charmers/`) or charmhub directly.
+- **Out of scope.** If the LP project is clearly an ops charm, reject per the SKILL.md "When NOT to use" list.
+
+## legacy
+
+- Very old format (pre-2014), no `metadata.yaml`, manually-managed hooks.
+- Effectively gone for OpenStack components.
+- **Out of scope** by virtue of irrelevance.
+
+## Interpreting a missing `stable/<release>` branch in a reactive OpenStack charm
+
+There are **three branch-naming styles** in the OpenStack charms ecosystem — and the same charm sometimes uses more than one over its history. Don't assume a policy.
+
+1. **`stable/<openstack-codename>`** — `stable/yoga`, `stable/caracal`. Older OpenStack-service charms.
+2. **`stable/<yyyy.N>`** — `stable/2024.1`. Newer OpenStack-service charms (post-codename retirement).
+3. **`stable/<ubuntu-series>`** — `stable/jammy`, `stable/focal`. **Data/infra charms** that follow Ubuntu's release cadence rather than OpenStack's: `charm-mysql-innodb-cluster`, `charm-percona-cluster`, `charm-rabbitmq-server`, and similar. For these, the bug's OpenStack release maps to its contemporaneous Ubuntu LTS via `common/openstack_release_info` (`lts[]`).
+
+The general pattern is one `stable/*` branch per OpenStack release — **including non-LTS** (e.g., `stable/xena`, `stable/wallaby`, `stable/2023.1`, `stable/2023.2`) — but the exact set varies per charm: some branch every release, some skip cycles, some have stopped branching recently. Always check actual branches:
+
+```
+git branch -r | grep stable | sort
+```
+
+If `stable/<bug-release>` is absent, decide by **activity**, not assumed policy. Run the activity heuristic (`git log --since "6 months ago" --oneline` per branch, also documented in `cross-branch.md` 8.4):
+
+- **Master active, recent stable active** → reproduce on the closest existing branch (most recent `stable/*` ≤ bug's release, or `master` if none), and flag in the report that the bug's exact release has no dedicated branch.
+- **Master active, all stables silent** → reproduce on `master`; backports may not be expected.
+- **All silent (master + stables)** → the charm may be deprecated; ask the user before guessing a new repo URL. Don't assume an ops migration for OpenStack VM charms — that route is rare and applies to K8s charms.

--- a/.agents/skills/stsstack-bug-repro/references/cross-branch.md
+++ b/.agents/skills/stsstack-bug-repro/references/cross-branch.md
@@ -1,0 +1,87 @@
+# Cross-branch fix status (step 6)
+
+After repro (success or failure), produce a branch-by-branch fix-status report and a recommended next action. Applies to both paths.
+
+## 8.1 Locate the fix commits
+
+```
+cd <charm-or-service-clone>
+git fetch --all
+git log --all --oneline \
+        --grep "Closes-Bug: #<num>" \
+        --grep "Related-Bug: #<num>" \
+        --grep "Partial-Bug: #<num>" \
+        --grep "LP#<num>" -i
+```
+
+If `git log --grep` returns nothing, **Gerrit fallback**:
+
+1. On the LP bug page, each `Fix proposed` / `Fix committed` / `Fix released` row links to a Gerrit review (`https://review.opendev.org/c/<project>/+/<n>`).
+2. WebFetch the Gerrit review and read the `Change-Id: I<hex>` from the commit message.
+3. Search the local repo by Change-Id:
+   ```
+   git log --all --oneline --grep "Change-Id: I<hex>"
+   ```
+4. Still nothing → the patch hasn't landed in this project's git tree yet (under review, abandoned, or in a different repo). Note this in the report.
+
+## 8.2 Enumerate target branches
+
+```
+git branch -r | grep -E '^  origin/(master|main|stable/.+)$'
+```
+
+## 8.3 Build the status table
+
+For each target branch:
+
+```
+git log <branch> --oneline --grep "Closes-Bug: #<num>" -i
+# or, with the fix SHA:
+git branch -r --contains <fix-sha>
+```
+
+Output:
+
+| Branch | Fix present | Commit |
+|---|---|---|
+| master | ✅ | abc1234 "Fix LP#<num> ..." |
+| stable/2025.1 | ✅ | def5678 (cherry-pick of abc1234) |
+| stable/2024.2 | ❌ | — |
+| stable/2024.1 | ❌ | — |
+
+## 8.4 Classify branch support — service vs charm rules differ
+
+**Service-level (upstream OpenStack) projects** follow the releases.openstack.org labels captured in SKILL.md step 3:
+
+- **Maintained** — receives bugfix backports.
+- **Extended Maintenance (EM)** — security/critical backports only, at community discretion.
+- **Unmaintained / EOL** — no backports.
+
+**Charm projects** (opendev `openstack/charm-*`) do NOT follow the upstream EOL clock 1:1. Canonical keeps older charm branches alive longer to track Ubuntu LTS support windows — `stable/yoga` may still receive patches long after upstream Yoga is EOL. Determine charm-branch support empirically:
+
+```
+git log <branch> --since "6 months ago" --oneline | head
+```
+
+If a branch has commits in the last ~6 months, treat it as **supported** (backport candidate) regardless of upstream OpenStack label. If silent for longer, treat it as **inactive** (no backport obligation). Record the rule and the most-recent commit date for each branch in your report.
+
+## 8.5 Recommend next action
+
+- **Fix absent everywhere (including master)** — guide patch progression. Order: master first, then active branches newest → oldest (service: Maintained; charm: empirically-supported). Per OpenStack stable policy, backports require the master merge first, then cherry-pick to each stable in sequence. State the order; don't skip branches. Also produce the patch proposal in 8.6.
+- **Fix on master only** — list backport candidates = every active stable. Call out EM/inactive stables separately as "optional, only if security-class". Exclude EOL.
+- **Fix on master + some stables** — list the remaining active stables that still need backports. Note inactive/EM stables that still lack the patch as optional.
+- **Fix on all active branches** — bug is fully fixed. Recommend closing the LP if still open. Optionally, keep a regression test exercising the trigger.
+
+Don't actually create patches, push to Gerrit, or modify branches. Output the plan; let the user act.
+
+## 8.6 Propose a patch when none exists
+
+If 8.1 found no fix on any branch and the repro succeeded, propose a concrete patch direction based on the reproduction evidence:
+
+1. **Symptom → suspected component** — from the failing command output, log line, or stack trace, identify the file:function most likely responsible (e.g., `nova/conductor/tasks/live_migrate.py::bind_ports_to_host`).
+2. **Inspect the code** — read that function on the reproduction branch. Match what the trace says against what the code does. Identify the exact condition, missing check, or wrong default.
+3. **Sketch the fix** — write the smallest change that addresses the root cause (not the symptom). Show it as a diff or function-level edit. Cite the file:line and the line of evidence from repro that maps to that line of code.
+4. **Suggest a test** — name the existing test that should have caught this (and didn't), or describe a new case. For charms, this usually maps to a `--func-test-target` or a new zaza test; for services, a unit/integration test in `<project>/tests/`.
+5. **Mark uncertainties** — flag what you couldn't verify from the repro alone (other code paths, race conditions, side effects on other releases).
+
+This is a proposal, not a merge — output the diff/sketch for the user to validate. Don't push, commit, or open a review.

--- a/.agents/skills/stsstack-bug-repro/references/release-mapping.md
+++ b/.agents/skills/stsstack-bug-repro/references/release-mapping.md
@@ -1,0 +1,31 @@
+# Release ↔ series mapping
+
+`common/openstack_release_info` in this repo is the **local ground truth** for what stsstack-bundles can deploy.
+
+## Structure
+
+```bash
+declare -A lts=( [jammy]=yoga [noble]=caracal ... )           # Ubuntu LTS ↔ contemporaneous OpenStack
+declare -A nonlts=( [plucky]=epoxy [questing]=flamingo ... )  # non-LTS Ubuntu ↔ OpenStack
+declare -A os_release_map=( [2023.1]=antelope [2024.1]=caracal ... )  # yyyy.N → codename
+declare -a lts_releases_sorted=( caracal yoga ussuri ... )    # ordered list of LTS-supported codenames
+```
+
+## Use
+
+- **Convert yyyy.N → codename** (for `--release`): look up `os_release_map[<yyyy.N>]`.
+- **Find Ubuntu series for a codename**: search `lts` and `nonlts` for the value, return the key.
+- **`--release` always takes a codename** (`caracal`, `epoxy`, `flamingo`), not yyyy.N. Only meaningful on LTS Ubuntu (UCA pocket).
+
+## Fallback when the bug's release isn't in the map
+
+If the release in the bug (or the current dev release from releases.openstack.org) is **not present** in `openstack_release_info`, stsstack-bundles can't deploy it directly via `--release`. Two options:
+
+1. **Fall back to the most recent supported release** — the last entry in `nonlts` or `lts_releases_sorted` — and note the deviation in the recipe. Reasonable when the bug isn't release-specific.
+2. **Ask the user** before proceeding — when the bug is plausibly release-specific (e.g., upgrade-path bug, new-feature bug).
+
+Don't silently substitute.
+
+## Why this matters
+
+releases.openstack.org tells us what *upstream OpenStack* knows about. `common/openstack_release_info` tells us what *this tool* can drive. The two can diverge (this tool lags behind upstream by a cycle or two). Always reconcile both before claiming a release is "supported".

--- a/.agents/skills/stsstack-bug-repro/references/service-path.md
+++ b/.agents/skills/stsstack-bug-repro/references/service-path.md
@@ -1,0 +1,87 @@
+# Service-level path (step 4B)
+
+Use this when the bug is in the OpenStack service code (not the charm) and you just need a representative cloud. stsstack-bundles' `openstack/` stack deploys it.
+
+## 4B.1 — Map dimensions to flags/overlays
+
+Read the repo every time — flags and overlays change. Read-only commands (no confirmation needed):
+
+- `./generate-bundle.sh --help` — authoritative options
+- `./generate-bundle.sh --list-overlays` — authoritative overlays
+- File reads: `openstack/module_defaults`, `openstack/pipeline/02configure`, `openstack/overlays/`, root `overlays/`, `openstack/profiles/<name>`
+
+### Flag syntax (confirmed from `--help`)
+
+- **Overlays** are passed as `--<overlayname>`, NOT `--overlay <name>`. Example: `--vault --octavia --ha`.
+- **HA-capable overlays** (marked with `*` in `--list-overlays`) accept unit count via colon: `--ha:3`, `--keystone-ha:3`, `--mysql-ha:3`.
+- `--release <name>` / `-r` — OpenStack release as a **codename** (`caracal`, `epoxy`, `flamingo`, ...), not `yyyy.N`. Only meaningful on LTS Ubuntu (UCA pocket).
+- `--series <name>` / `-s` — Ubuntu series.
+- `--name <name>` / `-n` — bundle and Juju model name; also creates/switches model unless `--no-create-model`.
+- `--run` — generate then `juju deploy` in one step.
+- `--charmstore` — use cs: instead of ch: (legacy charms only).
+- `--pocket <p>` / `-p` — archive pocket (e.g., `proposed`).
+- Module opts (`--num-compute <int>`, `--neutron-fw-driver <...>`, etc.) — see MODULE OPTS section of `--help`.
+
+Don't assume the existence of any other flag. If a knob is missing, say "no flag/overlay for X — would need a manual template/overlay edit" and stop. See `release-mapping.md` for the release/series mapping rules.
+
+## 4B.2 — Produce the recipe
+
+Use only flags/overlays you confirmed above. Keep it copy-pasteable.
+
+```
+## Reproduction summary
+<one paragraph: which LP bug, what conditions are needed>
+
+## Generate the bundle
+cd openstack/
+./generate-bundle.sh \
+    --release <codename> --series <series> \
+    --name <repro-name> \
+    [--<overlay1> --<overlay2>:<units> ...] \
+    [--num-compute <N> ...]
+
+## Deploy
+# generate-bundle.sh prints the exact deploy command(s) on completion — use those.
+# (Or pass --run to combine generate + deploy.)
+# Wait until `juju status` shows everything active/idle.
+
+## Post-deploy configuration
+./configure [profile] [net_type]
+
+## Trigger
+<exact commands the user must run to hit the bug>
+# If the symptom is intermittent, loop the trigger N times.
+
+## What to observe
+<exact symptom — which command's output, which log line, which juju status field>
+
+## Logs to collect if it fails to reproduce
+- juju status --format=yaml > status.yaml
+- juju debug-log --replay > debug.log
+- juju ssh <unit> 'sudo tar czf - /var/log/<service>' > <unit>-logs.tar.gz
+- <service-specific logs>
+```
+
+### Trigger patterns (service-level)
+
+Match the bug's trigger to one of these shapes:
+
+- **OpenStack CLI sequence** — `openstack server create ...`, `openstack loadbalancer create ...`
+- **REST API call** — `curl -H "X-Auth-Token: $TOKEN" ...`
+- **Charm config flip** — `juju config <app> <key>=<value>` then observe unit state
+- **Unit restart / failover** — `juju ssh <unit> 'sudo systemctl restart <svc>'`, `juju run --unit <unit> -- ...`
+- **Tempest / Rally** — usually from a controller or external node for service-level bugs
+- **Web UI navigation** — open Horizon at `https://<openstack-dashboard-vip>/horizon`, perform the action, capture the browser DevTools error and the apache/horizon logs from the openstack-dashboard unit (`/var/log/apache2/error.log`, `/var/log/apache2/openstack-dashboard.log`)
+- **Intermittent** — loop N times
+
+## 4B.3 — Assumptions and gaps
+
+End the recipe with:
+
+- **Assumed**: anything inferred but not in the bug (e.g., "assumed `noble` since release is Caracal")
+- **Needs the user to decide**: substrate (MAAS vs LXD), profile, anything depending on their environment
+- **Couldn't determine**: things truly missing from the input
+
+## 4B.4 — Verify
+
+See `SKILL.md` step 5.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary
- Add a Claude Code / Codex CLI skill (`.claude/skills/stsstack-bug-repro/`) that translates a public Launchpad bug into a reproduction recipe, classifies it as charm-path (clone opendev charm, run `charmed_openstack_functest_runner.sh`) or service-level path (deploy via stsstack-bundles, trigger manually), and reports cross-branch fix status with backport guidance
- Uses progressive disclosure: 127-line SKILL.md plus 5 references files loaded on demand (charm types, release mapping, charm path, service path, cross-branch)
- `.codex/skills/stsstack-bug-repro` is a directory symlink to `.claude/skills/stsstack-bug-repro` so both CLIs read the same source

## Test plan
- [ ] Walk through a charm-path bug (e.g., LP#2089616 on charm-keystone) — confirm classify + locate-fix-across-branches + activity-heuristic flow
- [ ] Walk through a service-level bug (e.g., LP#2051907 on nova) — confirm release-fallback (Hibiscus → Flamingo when not in openstack_release_info) and recipe generation
- [ ] Walk through a rejection case (e.g., LP#1979330 on charm-ceph-mon) — confirm "OpenStack-only" rejection
- [ ] Verify symlink resolves correctly on a fresh clone (Linux/macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)