### PR TITLE
Fix proxy configuration for ps7

### DIFF
--- a/cos/pipeline/02configure
+++ b/cos/pipeline/02configure
@@ -11,9 +11,16 @@ target=${target}:${MOD_PARAMS[__MICROK8S_CHANNEL__]}
 MOD_PASSTHROUGH_OPTS+=( --release-name $target )
 
 # Automatically use proxy if in prodstack only
-if $(timeout 1s getent hosts squid.internal &> /dev/null) && [ -z "${MOD_PARAMS[__CONTAINERD_PROXY__]}" ]; then
-    MOD_MSGS[1_proxy.0]='PROXY: squid.internal exists, setting containerd proxy to http://squid.internal:3128'
-    MOD_PARAMS[__CONTAINERD_PROXY__]=http://squid.internal:3128
+if [ -z "${MOD_PARAMS[__CONTAINERD_PROXY__]}" ]; then
+    if [[ -n ${http_proxy:-""} ]]; then
+        MOD_PARAMS[__CONTAINERD_PROXY__]=${http_proxy}
+    elif $(timeout 1s nc -vz egress.ps7.internal 3128 &> /dev/null); then
+        MOD_MSGS[1_proxy.0]='PROXY: egress.ps7.internal reachable, setting containerd proxy to http://egress.ps7.internal:3128'
+        MOD_PARAMS[__CONTAINERD_PROXY__]=http://egress.ps7.internal:3128
+    elif $(timeout 1s nc -vz squid.internal 3128 &> /dev/null); then
+        MOD_MSGS[1_proxy.0]='PROXY: squid.internal reachable, setting containerd proxy to http://squid.internal:3128'
+        MOD_PARAMS[__CONTAINERD_PROXY__]=http://squid.internal:3128
+    fi
 fi
 
 if ! has_opt --charmed-ceph-lxd && ! has_opt --microceph; then

--- a/identity-platform/configure
+++ b/identity-platform/configure
@@ -17,10 +17,20 @@ if ! snap list | grep -q helm; then
     sudo snap install helm --classic
 fi
 
+# Detect proxy
+_proxy=${https_proxy:-${http_proxy:-""}}
+if [[ -z "$_proxy" ]]; then
+    if $(timeout 1s nc -vz egress.ps7.internal 3128 &> /dev/null); then
+        _proxy=http://egress.ps7.internal:3128
+    elif $(timeout 1s nc -vz squid.internal 3128 &> /dev/null); then
+        _proxy=http://squid.internal:3128
+    fi
+fi
+
 # Install authentik
 kubectl get ns authentik &> /dev/null || kubectl create ns authentik
-https_proxy=http://squid.internal:3128 helm repo add authentik https://charts.goauthentik.io
-https_proxy=http://squid.internal:3128 helm repo update
+https_proxy=${_proxy} helm repo add authentik https://charts.goauthentik.io
+https_proxy=${_proxy} helm repo update
 helm install authentik authentik/authentik -f ./authentik-values.yaml -n authentik --version 2024.10.1
 
 timeout=0

--- a/microk8s/pipeline/02configure
+++ b/microk8s/pipeline/02configure
@@ -11,8 +11,13 @@ target=${target}:${MOD_PARAMS[__MICROK8S_CHANNEL__]}
 MOD_PASSTHROUGH_OPTS+=( --release-name $target )
 
 # Automatically use proxy if in prodstack only
-if $(timeout 1s getent hosts squid.internal &> /dev/null) && [ -z "${MOD_PARAMS[__CONTAINERD_PROXY__]}" ]; then
-    MOD_MSGS[1_proxy.0]='PROXY: squid.internal exists, setting containerd proxy to http://squid.internal:3128'
+if [[ -n ${http_proxy:-""} ]]; then
+    MOD_PARAMS[__CONTAINERD_PROXY__]=${http_proxy}
+elif $(timeout 1s nc -vz egress.ps7.internal 3128 &> /dev/null); then
+    MOD_MSGS[1_proxy.0]='PROXY: egress.ps7.internal reachable, setting containerd proxy to http://egress.ps7.internal:3128'
+    MOD_PARAMS[__CONTAINERD_PROXY__]=http://egress.ps7.internal:3128
+elif $(timeout 1s nc -vz squid.internal 3128 &> /dev/null); then
+    MOD_MSGS[1_proxy.0]='PROXY: squid.internal reachable, setting containerd proxy to http://squid.internal:3128'
     MOD_PARAMS[__CONTAINERD_PROXY__]=http://squid.internal:3128
 fi
 


### PR DESCRIPTION
This patch fixes the proxy configuration for modules cos, microk8s and identity-platform, applying the same scheme used in the kubernetes module.

The problem with `getent hosts squid.internal` is that it resolves squid.internal successfully in ps7 and  wrongly configure the ps6 address.