### PR TITLE
Fix charmed zaza runner for ps6

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -230,8 +230,8 @@ FIP_MIN_ABC=${FIP_MIN%.*}
 FIP_MIN_D=${FIP_MIN##*.}
 FIP_MIN=${FIP_MIN_ABC}.$(($FIP_MIN_D + 64))
 
-if [[ -n $http_proxy ]]; then
-    if [[ -n $no_proxy ]]; then
+if [[ -n ${http_proxy:-} ]]; then
+    if [[ -n ${no_proxy:-} ]]; then
         export no_proxy=$no_proxy,$CIDR_EXT
     else
         export no_proxy=$CIDR_EXT


### PR DESCRIPTION
PS6 does not require setting proxy-related environment vars. If 'http_proxy' or 'no_proxy' is unset the script will fail with the 'unbound variable' error. This patch fixes it.