### PR TITLE
Run func-target via tox-uv to avoid install_layout failure

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -424,7 +424,7 @@ for target in ${func_target_order[@]}; do
     _tmpdir_save=${TMPDIR:-}
     export TMPDIR=$TESTS_TMPDIR
     if ! $MANUAL_FUNCTESTS; then
-        tox ${tox_args} -- $_target || fail=true
+        uv run --with tox-uv tox ${tox_args} -- $_target || fail=true
         model=$(juju list-models| egrep -o "^zaza-\S+"|tr -d '*')
     else
         $TOOLS_PATH/manual_functests_runner.sh "$_target" $SLEEP $init_noop_target || fail=true


### PR DESCRIPTION
The func-target test run installs zaza, charm-tools, netifaces and friends from source. Under the host's setuptools that wheel build fails with AttributeError: install_layout. Running the env through tox-uv installs those deps with uv and sidesteps it.