### PR TITLE
Apply func-test-pr to all requirements files

### DIFF
--- a/openstack/tools/func_test_tools/common.sh
+++ b/openstack/tools/func_test_tools/common.sh
@@ -42,7 +42,9 @@ apply_func_test_pr ()
     msg=$(echo "Func-Test-Pr: https://github.com/openstack-charmers/zaza-openstack-tests/pull/$pr_id"| base64)
     ~/zosci-config/roles/handle-func-test-pr/files/process_func_test_pr.py \
         -f './test-requirements*.txt' \
+        -f './merged-requirements*.txt' \
         -f './src/test-requirements*.txt' \
+        -f './src/merged-requirements*.txt' \
         "$msg"
 }
 


### PR DESCRIPTION
Reactive charms use test-requirements-*.py to run
functional tests whereas classic charms use
merged-requirements-*.txt.