### PR TITLE
Clean leftover gateway ext-ports before func tests

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -411,6 +411,9 @@ for target in ${func_target_order[@]}; do
     # need.
     destroy_zaza_models
 
+    # Drop ext-ports the teardown leaked, before this model's FIPs are assigned.
+    $(dirname $0)/clean_orphan_dataports.sh || true
+
     # Only rebuild on first run.
     if $first; then
         first=false

--- a/openstack/tools/clean_orphan_dataports.sh
+++ b/openstack/tools/clean_orphan_dataports.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Delete leaked gateway ext-ports on the undercloud before a func test.
+#
+# Usage: clean_orphan_dataports.sh [OPENRC]   (default: ~/novarc)
+set -eu
+
+OPENRC=${1:-$HOME/novarc}
+if [[ ! -r $OPENRC ]]; then
+    echo "WARNING: no undercloud openrc ($OPENRC) - skipping ext-port cleanup" >&2
+    exit 0
+fi
+source "$OPENRC"
+if ! command -v openstack &>/dev/null; then
+    echo "WARNING: no openstack CLI - skipping ext-port cleanup" >&2
+    exit 0
+fi
+
+readarray -t ports < <(openstack port list -f value -c ID -c Name)
+deleted=0
+for line in "${ports[@]}"; do
+    read -r pid name <<< "$line"
+    [[ $name == *_ext-port ]] || continue
+    # Keep ports still bound to a live server; delete detached/stale (leaked) ones.
+    device_id=$(openstack port show "$pid" -c device_id -f value 2>/dev/null || true)
+    if [[ -n $device_id && $device_id != None ]]; then
+        openstack server show "$device_id" -c id -f value &>/dev/null && continue
+    fi
+    echo "Deleting leaked ext-port $pid ($name, device_id='${device_id}')"
+    openstack port delete "$pid" && deleted=$((deleted + 1))
+done
+
+echo "Deleted $deleted leaked ext-port(s)"


### PR DESCRIPTION
zaza creates an undercloud neutron port <server>_ext-port and attaches it to each gateway instance with interface_attach.
nova does not delete such a user-supplied port on teardown - it only detaches it and leaves it behind.
juju usually cleans it up - its openstack provider deletes ports filtered by device_id == server
but if nova clears device_id before that query runs, or the port delete errors out, or teardown is forced, the detached port survives on the shared external network. 
A later test whose floating IP lands on that leaked address then collides with the dead port at L2/ARP and can't reach its guest, so the failure shows up intermittently.
Before each model is built, delete ext-ports that are detached or whose device_id points at a gone instance; a port still attached to a live server is left alone.

This does not fully fix the leak. The teardown is async, so it can miss the port from the last model.
But it cleans old leaked ports before each build, so the collision is much less likely.