### PR TITLE
Fix ssl/create_ca_cert.sh all_exist check

### DIFF
--- a/ssl/create_ca_cert.sh
+++ b/ssl/create_ca_cert.sh
@@ -5,7 +5,7 @@ declare -a required=( cacert.pem servercert.csr servercert.pem )
 
 all_exist=true
 for f in ${required[@]}; do
-    [ -r "$results_dir/$f" ] || all_exist=false && break
+    [ -r "$results_dir/$f" ] || { all_exist=false; break; }
 done
 
 if $all_exist; then


### PR DESCRIPTION
## Summary

Fix the existing SSL certificate detection logic in `ssl/create_ca_cert.sh`.

The previous condition always broke out of the loop after checking the first required file. This meant the script could incorrectly reuse existing certificates when only `cacert.pem` was present and other required files were missing.

## Changes

Group the missing-file branch with `{ all_exist=false; break; }`                                                                                                                                                                                       