### PR TITLE
Fix functest exit phase return code

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -148,7 +148,7 @@ EOF
             ;;
         exit)
             echo "INFO: exiting re-run"
-            return
+            return 1
             ;;
         *)
             echo "ERROR: unrecognised phase name '$phase'"


### PR DESCRIPTION
If we exit a functest run we need to mark the test as failed.